### PR TITLE
pin asyncapi/specs to v 6.10.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,5 +65,8 @@
     "workerDirectory": [
       "public"
     ]
+  },
+  "overrides": {
+    "@asyncapi/specs": "6.10.0"
   }
 }


### PR DESCRIPTION
Even though `@stoplight/spectral-rulesets` still declares `^6.8.0` (line 2928), npm will always resolve it to
   `6.10.0` due to the override, protecting against future drift to vulnerable versions like `6.10.1`.

__

In response to:

I reviewed our package-lock.json for smartem-frontend and noticed that the project has a transitive dependency on @asyncapi/specs via @stoplight/spectral-rulesets. The lockfile currently seems to resolve this to version 6.10.0, which is not one of the versions on our flagged list, so there doesn't seem to be any immediate risk.
However, the declared semver range (^6.8.0) does allow installation of the known-vulnerable versions if the lockfile is ever regenerated or not respected. To avoid any future drift, would you be open to pinning this dependency to a known-good version?
Known vulnerable versions:
@asyncapi/specs= 6.9.1 || = 6.10.1 || = 6.8.3 || = 6.8.2
For further information
[Sha1-Hulud 2.0 Supply Chain Attack: 25K+ Repos Exposed | Wiz Blog](https://www.wiz.io/blog/shai-hulud-2-0-ongoing-supply-chain-attack)