### PR TITLE
Configure Dependabot to use admin+devops labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,38 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
-  - package-ecosystem: 'npm' # See documentation for possible values
-    directory: '/' # Location of package manifests
+  - package-ecosystem: "npm"
+    directory: "/"
     schedule:
-      interval: 'weekly'
+      interval: "weekly"
+    labels:
+      - "admin"
+      - "devops"
+    groups:
+      npm-minor:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "admin"
+      - "devops"
+    groups:
+      actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "admin"
+      - "devops"
+    groups:
+      docker:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Add explicit `labels:` configuration to all Dependabot ecosystems
- Prevents Dependabot from auto-creating default labels (`dependencies`, `github_actions`, `javascript`)
- Add github-actions ecosystem for workflow updates
- Add docker ecosystem for base image updates

## Test plan
- [ ] Verify Dependabot config syntax is valid
- [ ] After merge, trigger Dependabot or wait for next scheduled run
- [ ] Confirm new PRs have `admin` + `devops` labels