### PR TITLE
fix: update API generation scripts with correct paths and URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "typecheck": "tsc",
     "router:generate": "tsr generate",
     "router:check": "tsr generate && git diff --exit-code src/routeTree.gen.ts",
-    "api:fetch": "curl -s https://diamondlightsource.github.io/smartem-decisions/main/api/smartem/swagger.json -o src/api/openapi.json",
+    "api:fetch": "curl -s https://diamondlightsource.github.io/smartem-devtools/api/smartem/swagger.json -o src/api/openapi.json",
     "api:fetch:local": "curl -s http://localhost:8000/openapi.json -o src/api/openapi.json",
     "api:generate": "orval --config orval.config.ts && node scripts/extract-api-version.js",
     "api:update": "npm run api:fetch && npm run api:generate",

--- a/scripts/extract-api-version.js
+++ b/scripts/extract-api-version.js
@@ -6,8 +6,8 @@ import { fileURLToPath } from 'node:url'
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
 
-const openApiPath = join(__dirname, '../app/api/openapi.json')
-const versionPath = join(__dirname, '../app/api/generated/api-version.ts')
+const openApiPath = join(__dirname, '../src/api/openapi.json')
+const versionPath = join(__dirname, '../src/api/generated/api-version.ts')
 
 try {
   const openApiSpec = JSON.parse(readFileSync(openApiPath, 'utf-8'))


### PR DESCRIPTION
## Summary

- Update `extract-api-version.js` paths from `app/api/` to `src/api/` to match actual directory structure
- Update `api:fetch` URL to use smartem-devtools instead of smartem-decisions (docs were migrated)

Fixes #43
Fixes #44

## Test plan

- [x] `npm run api:fetch` downloads openapi.json successfully
- [x] `npm run api:generate` generates API client and extracts version
- [x] `src/api/generated/api-version.ts` updated with correct version
- [x] `npm run typecheck` passes