### PR TITLE
fix: correct Renovate preset path and migrate matchPackagePatterns

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>DiamondLightSource/smartem-devtools:renovate/default"],
+  "extends": ["github>DiamondLightSource/smartem-devtools//renovate/default"],
   "packageRules": [
     {
       "description": "Group npm minor/patch",
@@ -12,21 +12,21 @@
       "description": "Group vite ecosystem majors",
       "matchManagers": ["npm"],
       "matchUpdateTypes": ["major"],
-      "matchPackagePatterns": ["^vite$", "^@vitejs/", "^@tailwindcss/vite$"],
+      "matchPackageNames": ["vite", "@tailwindcss/vite", "/^@vitejs//"],
       "groupName": "vite ecosystem major"
     },
     {
       "description": "Group React ecosystem majors",
       "matchManagers": ["npm"],
       "matchUpdateTypes": ["major"],
-      "matchPackagePatterns": ["^react$", "^react-dom$", "^@types/react"],
+      "matchPackageNames": ["react", "react-dom", "/^@types/react/"],
       "groupName": "react ecosystem major"
     },
     {
       "description": "Group MUI majors",
       "matchManagers": ["npm"],
       "matchUpdateTypes": ["major"],
-      "matchPackagePatterns": ["^@mui/"],
+      "matchPackageNames": ["/^@mui//"],
       "groupName": "MUI major"
     }
   ]


### PR DESCRIPTION
## Summary

Two related Renovate config cleanups in one PR.

### 1. Preset path uses wrong separator (blocking)

Renovate's preset reference uses \`:\` for **sub-preset names** within a single file and \`//\` for **nested file paths**. The shared preset lives at \`renovate/default.json\` in smartem-devtools, so the correct reference is:

\`\`\`
github>DiamondLightSource/smartem-devtools//renovate/default
\`\`\`

The previous \`:\` form fails preset resolution (\"Preset name not found within published preset config\"), so Renovate cannot process this repo at all.

Same root cause and fix as DiamondLightSource/smartem-decisions#281.

### 2. matchPackagePatterns -> matchPackageNames (cosmetic)

\`matchPackagePatterns\` was deprecated and Renovate auto-migrates it to \`matchPackageNames\` with the embedded \`/regex/\` syntax on every run. The auto-migration is silent and harmless, but pinning the replacement in source makes intent explicit and removes the migration step. Exact-name matches now use plain strings (e.g. \`\"vite\"\`); prefix patterns keep regex form (e.g. \`\"/^@vitejs//\"\`).

Found while sweeping the org for misconfiguration #1.

## Test plan

- [x] \`renovate-config-validator --strict\` passes
- [ ] After merge, confirm Renovate runs cleanly and the package-rule groups still trigger as expected on the next major-version bump