### PR TITLE
chore: easy wins from frontend roadmap (#39)

### DIFF
--- a/apps/legacy/package.json
+++ b/apps/legacy/package.json
@@ -18,7 +18,7 @@
     "@mui/icons-material": "^7.3.9",
     "@mui/material": "^7.0.2",
     "@mui/x-charts": "^8.28.0",
-    "@tanstack/react-query": "^5.95.2",
+    "@tanstack/react-query": "^5.100.6",
     "@tanstack/react-router": "^1.168.3",
     "@tanstack/router-devtools": "^1.166.11",
     "boring-avatars": "^2.0.4",
@@ -28,6 +28,7 @@
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.2.2",
+    "@tanstack/react-query-devtools": "^5.100.6",
     "@tanstack/router-cli": "^1.166.18",
     "@tanstack/router-vite-plugin": "^1.166.19",
     "@types/d3-array": "^3.2.1",

--- a/apps/legacy/src/components/atlas.tsx
+++ b/apps/legacy/src/components/atlas.tsx
@@ -10,7 +10,7 @@ import {
 } from '@mui/material'
 import type { GridSquareResponse } from '@smartem/api'
 import { apiUrl } from '@smartem/api'
-import React from 'react'
+import { useEffect, useState } from 'react'
 import { theme } from '../components/theme'
 
 type GridSquare = GridSquareResponse
@@ -22,12 +22,12 @@ export default function Atlas({
   params: { gridId: string }
   onClose: () => void
 }) {
-  // const [maxWidth, setMaxWidth] = React.useState(0);
-  // const [squareNameMap, setSquareNameMap] = React.useState<Map<string, string>>()
-  const [selectedSquare, setSelectedSquare] = React.useState('')
-  const [squares, setSquares] = React.useState<GridSquare[]>([])
+  // const [maxWidth, setMaxWidth] = useState(0);
+  // const [squareNameMap, setSquareNameMap] = useState<Map<string, string>>()
+  const [selectedSquare, setSelectedSquare] = useState('')
+  const [squares, setSquares] = useState<GridSquare[]>([])
 
-  const [selectionFrozen, setSelectionFrozen] = React.useState(false)
+  const [selectionFrozen, setSelectionFrozen] = useState(false)
 
   const handleSelectionClick = (uuid: string) => {
     if (uuid === selectedSquare) {
@@ -38,7 +38,7 @@ export default function Atlas({
     }
   }
 
-  React.useEffect(() => {
+  useEffect(() => {
     const loadData = async () => {
       const gridsquares = await fetch(`${apiUrl()}/grids/${params.gridId}/gridsquares`)
       const squares = await gridsquares.json()

--- a/apps/legacy/src/components/latentRep.tsx
+++ b/apps/legacy/src/components/latentRep.tsx
@@ -25,7 +25,8 @@ import type {
   QualityPredictionResponse,
 } from '@smartem/api'
 import { apiUrl } from '@smartem/api'
-import React from 'react'
+import type React from 'react'
+import { useEffect, useId, useState } from 'react'
 import { Navbar } from '../components/navbar'
 import { theme } from '../components/theme'
 
@@ -72,23 +73,23 @@ export default function Atlas({
   loaderData: { squares: GridSquare[]; models: PredictionModel[] }
   params: { gridId: string }
 }) {
-  const modelSelectLabelId = React.useId()
-  const modelSelectId = React.useId()
-  const repModelSelectLabelId = React.useId()
-  const repModelSelectId = React.useId()
-  const [maxWidth, setMaxWidth] = React.useState(0)
-  const [squareNameMap, setSquareNameMap] = React.useState<Map<string, string>>()
-  const [selectedSquare, setSelectedSquare] = React.useState('')
-  const [showPredictions, setShowPredictions] = React.useState(false)
-  const [predictionModel, setPredictionModel] = React.useState('')
-  const [repModel, setRepModel] = React.useState('')
-  const [predictions, setPredictions] = React.useState<Map<string, number>>()
-  const [predictionMin, setPredictionMin] = React.useState(0)
-  const [predictionMax, setPredictionMax] = React.useState(0)
-  const [latentRep, setLatentRep] = React.useState<Map<string, Coords>>()
-  const [showLatentSpace, setShowLatentSpace] = React.useState(false)
-  const [showUnselectedInLatentSpace, setShowUnselectedInLatentSpace] = React.useState(true)
-  const [selectionFrozen, setSelectionFrozen] = React.useState(false)
+  const modelSelectLabelId = useId()
+  const modelSelectId = useId()
+  const repModelSelectLabelId = useId()
+  const repModelSelectId = useId()
+  const [maxWidth, setMaxWidth] = useState(0)
+  const [squareNameMap, setSquareNameMap] = useState<Map<string, string>>()
+  const [selectedSquare, setSelectedSquare] = useState('')
+  const [showPredictions, setShowPredictions] = useState(false)
+  const [predictionModel, setPredictionModel] = useState('')
+  const [repModel, setRepModel] = useState('')
+  const [predictions, setPredictions] = useState<Map<string, number>>()
+  const [predictionMin, setPredictionMin] = useState(0)
+  const [predictionMax, setPredictionMax] = useState(0)
+  const [latentRep, setLatentRep] = useState<Map<string, Coords>>()
+  const [showLatentSpace, setShowLatentSpace] = useState(false)
+  const [showUnselectedInLatentSpace, setShowUnselectedInLatentSpace] = useState(true)
+  const [selectionFrozen, setSelectionFrozen] = useState(false)
 
   const colourPalette = [
     '#E3B505',
@@ -131,7 +132,7 @@ export default function Atlas({
     }
   }
 
-  React.useEffect(() => {
+  useEffect(() => {
     const widths = loaderData.squares
       .map((elem: GridSquare) => elem.size_width)
       .filter((w): w is number => w !== null)
@@ -143,7 +144,7 @@ export default function Atlas({
     )
   }, [loaderData.squares])
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (predictions) {
       setPredictionMin(Math.min(...Array.from(predictions).map((k, _v) => k[1])))
       setPredictionMax(Math.max(...Array.from(predictions).map((k, _v) => k[1])))

--- a/apps/legacy/src/components/navbar.tsx
+++ b/apps/legacy/src/components/navbar.tsx
@@ -14,12 +14,12 @@ import {
 } from '@mui/material'
 import AppBar from '@mui/material/AppBar'
 import { useNavigate } from '@tanstack/react-router'
-import React from 'react'
+import { useState } from 'react'
 
 export const Navbar = () => {
   const navigate = useNavigate()
 
-  const [drawer, setDrawer] = React.useState(false)
+  const [drawer, setDrawer] = useState(false)
 
   return (
     <Box sx={{ display: 'flex' }}>

--- a/apps/legacy/src/components/timeseries.tsx
+++ b/apps/legacy/src/components/timeseries.tsx
@@ -15,7 +15,7 @@ import {
 import type { AxisValueFormatterContext } from '@mui/x-charts'
 import { LineChart } from '@mui/x-charts'
 
-import React from 'react'
+import { useState } from 'react'
 
 export const TimeSeriesChart = ({
   xData,
@@ -24,8 +24,8 @@ export const TimeSeriesChart = ({
   xData: number[] | Date[]
   yData: number[]
 }) => {
-  const [axisRange, setAxisRange] = React.useState([0, xData.length])
-  const [timeScale, setTimeScale] = React.useState(true)
+  const [axisRange, setAxisRange] = useState([0, xData.length])
+  const [timeScale, setTimeScale] = useState(true)
 
   const average =
     yData.length === 0 ? 0 : yData.reduce((a: number, b: number) => a + b, 0) / yData.length

--- a/apps/legacy/src/routes/__root.tsx
+++ b/apps/legacy/src/routes/__root.tsx
@@ -1,4 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import { createRootRoute, Outlet } from '@tanstack/react-router'
 import { TanStackRouterDevtools } from '@tanstack/router-devtools'
 import { ApiVersionCheck } from '../components/ApiVersionCheck'
@@ -22,6 +23,7 @@ function RootComponent() {
       <Outlet />
       <ApiVersionCheck />
       <TanStackRouterDevtools />
+      {import.meta.env.DEV && <ReactQueryDevtools initialIsOpen={false} />}
     </QueryClientProvider>
   )
 }

--- a/apps/legacy/src/routes/acquisitions.$acqId.grids.$gridId.atlas.tsx
+++ b/apps/legacy/src/routes/acquisitions.$acqId.grids.$gridId.atlas.tsx
@@ -36,7 +36,8 @@ import {
   getPredictionModelsPredictionModelsGet,
 } from '@smartem/api'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
-import React from 'react'
+import type React from 'react'
+import { useEffect, useId, useState } from 'react'
 
 import { Navbar } from '../components/navbar'
 import { theme } from '../components/theme'
@@ -91,17 +92,17 @@ const getSuggestion = async (gridId: string) => {
 function Atlas() {
   const { acqId, gridId } = Route.useParams()
   const navigate = useNavigate()
-  const modelSelectLabelId = React.useId()
-  const modelSelectId = React.useId()
-  const repModelSelectLabelId = React.useId()
-  const repModelSelectId = React.useId()
-  const [squares, setSquares] = React.useState<GridSquare[]>([])
-  const [models, setModels] = React.useState<PredictionModel[]>([])
-  const [maxWidth, setMaxWidth] = React.useState(0)
-  const [squareNameMap, setSquareNameMap] = React.useState<Map<string, string>>()
-  const [selectedSquare, setSelectedSquare] = React.useState('')
+  const modelSelectLabelId = useId()
+  const modelSelectId = useId()
+  const repModelSelectLabelId = useId()
+  const repModelSelectId = useId()
+  const [squares, setSquares] = useState<GridSquare[]>([])
+  const [models, setModels] = useState<PredictionModel[]>([])
+  const [maxWidth, setMaxWidth] = useState(0)
+  const [squareNameMap, setSquareNameMap] = useState<Map<string, string>>()
+  const [selectedSquare, setSelectedSquare] = useState('')
 
-  React.useEffect(() => {
+  useEffect(() => {
     const fetchData = async () => {
       if (!gridId) return
       const squaresData = await getGridGridsquaresGridsGridUuidGridsquaresGet(gridId)
@@ -111,17 +112,17 @@ function Atlas() {
     }
     fetchData()
   }, [gridId])
-  const [showPredictions, setShowPredictions] = React.useState(false)
-  const [predictionModel, setPredictionModel] = React.useState('')
-  const [repModel, setRepModel] = React.useState('')
-  const [predictions, setPredictions] = React.useState<Map<string, number>>()
-  const [predictionMin, setPredictionMin] = React.useState(0)
-  const [predictionMax, setPredictionMax] = React.useState(0)
-  const [latentRep, setLatentRep] = React.useState<Map<string, Coords>>()
-  const [showLatentSpace, setShowLatentSpace] = React.useState(false)
-  const [showUnselectedInLatentSpace, setShowUnselectedInLatentSpace] = React.useState(true)
-  const [selectionFrozen, setSelectionFrozen] = React.useState(false)
-  const [suggestions, setSuggestions] = React.useState<string[]>([])
+  const [showPredictions, setShowPredictions] = useState(false)
+  const [predictionModel, setPredictionModel] = useState('')
+  const [repModel, setRepModel] = useState('')
+  const [predictions, setPredictions] = useState<Map<string, number>>()
+  const [predictionMin, setPredictionMin] = useState(0)
+  const [predictionMax, setPredictionMax] = useState(0)
+  const [latentRep, setLatentRep] = useState<Map<string, Coords>>()
+  const [showLatentSpace, setShowLatentSpace] = useState(false)
+  const [showUnselectedInLatentSpace, setShowUnselectedInLatentSpace] = useState(true)
+  const [selectionFrozen, setSelectionFrozen] = useState(false)
+  const [suggestions, setSuggestions] = useState<string[]>([])
 
   const colourPalette = [
     '#f2a2a9',
@@ -169,7 +170,7 @@ function Atlas() {
     setSuggestions(suggestions)
   }
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (squares.length > 0) {
       const widths = squares
         .map((elem: GridSquare) => elem.size_width)
@@ -181,7 +182,7 @@ function Atlas() {
     }
   }, [squares])
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (predictions) {
       setPredictionMin(Math.min(...Array.from(predictions).map((k, _v) => k[1])))
       setPredictionMax(Math.max(...Array.from(predictions).map((k, _v) => k[1])))

--- a/apps/legacy/src/routes/acquisitions.$acqId.grids.$gridId.gridsquares.tsx
+++ b/apps/legacy/src/routes/acquisitions.$acqId.grids.$gridId.gridsquares.tsx
@@ -15,7 +15,8 @@ import {
 import type { GridSquareResponse } from '@smartem/api'
 import { useGetGridGridsquaresGridsGridUuidGridsquaresGet } from '@smartem/api'
 import { createFileRoute } from '@tanstack/react-router'
-import React from 'react'
+import type React from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { Navbar } from '../components/navbar'
 import { theme } from '../components/theme'
 
@@ -27,22 +28,22 @@ function GridSquareGallery() {
     error,
   } = useGetGridGridsquaresGridsGridUuidGridsquaresGet(gridId)
 
-  const [pageIndex, setPageIndex] = React.useState(0)
-  const [numPages, setNumPages] = React.useState(Math.ceil((squares?.length || 0) / 9))
-  const [showCollectedOnly, setShowCollectedOnly] = React.useState(false)
-  const [filteredSquares, setFilteredSquares] = React.useState<GridSquareResponse[]>([])
+  const [pageIndex, setPageIndex] = useState(0)
+  const [numPages, setNumPages] = useState(Math.ceil((squares?.length || 0) / 9))
+  const [showCollectedOnly, setShowCollectedOnly] = useState(false)
+  const [filteredSquares, setFilteredSquares] = useState<GridSquareResponse[]>([])
 
   const handlePageChange = (_event: React.ChangeEvent<unknown>, value: number) => {
     setPageIndex(value - 1)
   }
 
-  const sizeComparator = React.useCallback((gs01: GridSquareResponse, gs02: GridSquareResponse) => {
+  const sizeComparator = useCallback((gs01: GridSquareResponse, gs02: GridSquareResponse) => {
     if (gs01.size_height === null || gs01.size_width === null) return 1
     else if (gs02.size_height === null || gs02.size_width === null) return -1
     return gs02.size_width * gs02.size_height - gs01.size_width * gs01.size_height
   }, [])
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (squares) {
       setFilteredSquares(
         showCollectedOnly
@@ -56,7 +57,7 @@ function GridSquareGallery() {
     }
   }, [showCollectedOnly, squares, sizeComparator])
 
-  React.useEffect(() => {
+  useEffect(() => {
     setNumPages(Math.ceil(filteredSquares.length / 9))
   }, [filteredSquares])
 

--- a/apps/legacy/src/routes/acquisitions.$acqId.grids.$gridId.index.tsx
+++ b/apps/legacy/src/routes/acquisitions.$acqId.grids.$gridId.index.tsx
@@ -24,7 +24,7 @@ import {
 } from '@smartem/api'
 import { useQueries } from '@tanstack/react-query'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
-import React from 'react'
+import React, { useMemo, useState } from 'react'
 import { Navbar } from '../components/navbar'
 import { theme } from '../components/theme'
 
@@ -43,8 +43,8 @@ type FullSquareDetails = {
 }
 
 const CollapsibleRow = ({ square, holes, weightedPredictions }: FullSquareDetails) => {
-  const [open, setOpen] = React.useState(false)
-  const [sortOrderDescending, setSortOrderDescending] = React.useState(true)
+  const [open, setOpen] = useState(false)
+  const [sortOrderDescending, setSortOrderDescending] = useState(true)
   const { acqId, gridId } = Route.useParams()
   const navigate = useNavigate()
 
@@ -159,8 +159,8 @@ const CollapsibleRow = ({ square, holes, weightedPredictions }: FullSquareDetail
 
 function Grid() {
   const { gridId } = Route.useParams()
-  const [holeNumberOrder, _setHoleNumberOrder] = React.useState(true)
-  const [sortOrderDescending, setSortOrderDescending] = React.useState(true)
+  const [holeNumberOrder, _setHoleNumberOrder] = useState(true)
+  const [sortOrderDescending, setSortOrderDescending] = useState(true)
 
   const {
     data: squares_data,
@@ -180,7 +180,7 @@ function Grid() {
       })) || [],
   })
 
-  const squares: SquareDetails[] = React.useMemo(() => {
+  const squares: SquareDetails[] = useMemo(() => {
     if (!squares_data) return []
     return squares_data.map((square, index) => ({
       square,

--- a/apps/legacy/src/routes/acquisitions.$acqId.grids.$gridId.square.$squareId.predictions.tsx
+++ b/apps/legacy/src/routes/acquisitions.$acqId.grids.$gridId.square.$squareId.predictions.tsx
@@ -17,7 +17,7 @@ import type { QualityPrediction } from '@smartem/api'
 import { apiUrl } from '@smartem/api'
 import { createFileRoute } from '@tanstack/react-router'
 import { bin } from 'd3-array'
-import React from 'react'
+import { useEffect, useId, useState } from 'react'
 import { Navbar } from '../components/navbar'
 import { theme } from '../components/theme'
 
@@ -64,7 +64,7 @@ const FoilHolePredictionCharts = ({
       return Date.parse(value[0].timestamp)
     })
   )
-  const [selectedTime, setSelectedTime] = React.useState(mostRecentTimestamp)
+  const [selectedTime, setSelectedTime] = useState(mostRecentTimestamp)
   const histGenerator = bin().domain([0, 1]).thresholds(19)
 
   const getMostRecentBefore = (preds: QualityPrediction[]) => {
@@ -123,17 +123,17 @@ const FoilHolePredictionCharts = ({
 
 function QualityPredictionsForSquare() {
   const { squareId } = Route.useParams()
-  const metricSelectLabelId = React.useId()
-  const metricSelectId = React.useId()
-  const [squarePredictions, setSquarePredictions] = React.useState<
-    Record<string, QualityPrediction[]>
-  >({})
-  const [holePredictions, setHolePredictions] = React.useState<
+  const metricSelectLabelId = useId()
+  const metricSelectId = useId()
+  const [squarePredictions, setSquarePredictions] = useState<Record<string, QualityPrediction[]>>(
+    {}
+  )
+  const [holePredictions, setHolePredictions] = useState<
     Record<string, Record<string, QualityPrediction[]>>
   >({})
-  const [metrics, setMetrics] = React.useState<{ name: string }[]>([])
+  const [metrics, setMetrics] = useState<{ name: string }[]>([])
 
-  React.useEffect(() => {
+  useEffect(() => {
     const fetchData = async () => {
       const squarePredictionsResponse = await fetch(
         `${apiUrl()}/gridsquares/${squareId}/quality_predictions`
@@ -159,8 +159,8 @@ function QualityPredictionsForSquare() {
     return mostRecents.reduce((a: number, b: number) => a + b, 0) / mostRecents.length
   }
 
-  const [metricName, setMetricName] = React.useState('')
-  const [predictionsPerMetric, setPredictionsPerMetric] = React.useState<
+  const [metricName, setMetricName] = useState('')
+  const [predictionsPerMetric, setPredictionsPerMetric] = useState<
     Record<string, Record<string, QualityPrediction[]>>
   >({})
 

--- a/apps/legacy/src/routes/acquisitions.$acqId.grids.$gridId.squares.$squareId.tsx
+++ b/apps/legacy/src/routes/acquisitions.$acqId.grids.$gridId.squares.$squareId.tsx
@@ -27,7 +27,8 @@ import type {
 } from '@smartem/api'
 import { apiUrl } from '@smartem/api'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
-import React from 'react'
+import type React from 'react'
+import { useEffect, useId, useState } from 'react'
 import { Navbar } from '../components/navbar'
 import { theme } from '../components/theme'
 
@@ -81,16 +82,16 @@ const getLatentRep = async (modelName: string, gridSquareId: string) => {
 function GridSquareLR() {
   const { acqId, gridId, squareId } = Route.useParams()
   const navigate = useNavigate()
-  const modelSelectLabelId = React.useId()
-  const modelSelectId = React.useId()
-  const repModelSelectLabelId = React.useId()
-  const repModelSelectId = React.useId()
-  const [holes, setHoles] = React.useState<FoilHole[]>([])
-  const [models, setModels] = React.useState<PredictionModel[]>([])
-  const [maxWidth] = React.useState(0)
-  const [selectedSquare, setSelectedSquare] = React.useState('')
+  const modelSelectLabelId = useId()
+  const modelSelectId = useId()
+  const repModelSelectLabelId = useId()
+  const repModelSelectId = useId()
+  const [holes, setHoles] = useState<FoilHole[]>([])
+  const [models, setModels] = useState<PredictionModel[]>([])
+  const [maxWidth] = useState(0)
+  const [selectedSquare, setSelectedSquare] = useState('')
 
-  React.useEffect(() => {
+  useEffect(() => {
     const fetchData = async () => {
       const foilholesResponse = await fetch(
         `${apiUrl()}/gridsquares/${squareId}/foilholes?on_square_only=true`
@@ -103,18 +104,18 @@ function GridSquareLR() {
     }
     fetchData()
   }, [squareId])
-  const [holeNameMap, setHoleNameMap] = React.useState<Map<string, string>>()
-  const [selectedHole, setSelectedHole] = React.useState('')
-  const [showPredictions, setShowPredictions] = React.useState(false)
-  const [predictionModel, setPredictionModel] = React.useState('')
-  const [repModel, setRepModel] = React.useState('')
-  const [predictions, setPredictions] = React.useState<Map<string, number>>()
-  const [predictionMin, setPredictionMin] = React.useState(0)
-  const [predictionMax, setPredictionMax] = React.useState(1)
-  const [latentRep, setLatentRep] = React.useState<Map<string, Coords>>()
-  const [showLatentSpace, setShowLatentSpace] = React.useState(false)
-  const [showUnselectedInLatentSpace, setShowUnselectedInLatentSpace] = React.useState(true)
-  const [selectionFrozen, setSelectionFrozen] = React.useState(false)
+  const [holeNameMap, setHoleNameMap] = useState<Map<string, string>>()
+  const [selectedHole, setSelectedHole] = useState('')
+  const [showPredictions, setShowPredictions] = useState(false)
+  const [predictionModel, setPredictionModel] = useState('')
+  const [repModel, setRepModel] = useState('')
+  const [predictions, setPredictions] = useState<Map<string, number>>()
+  const [predictionMin, setPredictionMin] = useState(0)
+  const [predictionMax, setPredictionMax] = useState(1)
+  const [latentRep, setLatentRep] = useState<Map<string, Coords>>()
+  const [showLatentSpace, setShowLatentSpace] = useState(false)
+  const [showUnselectedInLatentSpace, setShowUnselectedInLatentSpace] = useState(true)
+  const [selectionFrozen, setSelectionFrozen] = useState(false)
 
   const colourPalette = [
     '#f2a2a9',
@@ -165,7 +166,7 @@ function GridSquareLR() {
     }
   }
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (holes.length > 0) {
       setHoleNameMap(
         new Map<string, string>(holes.map((elem: FoilHole) => [elem.uuid, elem.foilhole_id]))
@@ -173,7 +174,7 @@ function GridSquareLR() {
     }
   }, [holes])
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (predictions) {
       const min = Math.min(...Array.from(predictions).map((k) => k[1]))
       const max = Math.max(...Array.from(predictions).map((k) => k[1]))

--- a/apps/legacy/src/routes/acquisitions.$acqId.grids.$gridId.workspace.tsx
+++ b/apps/legacy/src/routes/acquisitions.$acqId.grids.$gridId.workspace.tsx
@@ -3,15 +3,16 @@ import KeyboardArrowDown from '@mui/icons-material/KeyboardArrowDown'
 import KeyboardArrowUp from '@mui/icons-material/KeyboardArrowUp'
 import { Container, IconButton, Menu, MenuItem, Paper, Stack, ThemeProvider } from '@mui/material'
 import { createFileRoute } from '@tanstack/react-router'
-import React from 'react'
+import type React from 'react'
+import { useState } from 'react'
 import Atlas from '../components/atlas'
 import { Navbar } from '../components/navbar'
 import { theme } from '../components/theme'
 
 function Workspace() {
   const { gridId } = Route.useParams()
-  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null)
-  const [atlasView, setAtlasView] = React.useState(false)
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
+  const [atlasView, setAtlasView] = useState(false)
   const open = Boolean(anchorEl)
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(event.currentTarget)

--- a/apps/legacy/src/routes/index.tsx
+++ b/apps/legacy/src/routes/index.tsx
@@ -19,7 +19,8 @@ import Paper from '@mui/material/Paper'
 import type { AcquisitionResponse } from '@smartem/api'
 import { useGetAcquisitionsAcquisitionsGet } from '@smartem/api'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
-import React from 'react'
+import type React from 'react'
+import { useState } from 'react'
 import { Navbar } from '../components/navbar'
 import { theme } from '../components/theme'
 
@@ -28,7 +29,7 @@ export const Route = createFileRoute('/')({
 })
 
 function Home() {
-  const [menuToggle, setMenuToggle] = React.useState(false)
+  const [menuToggle, setMenuToggle] = useState(false)
   const { data: acquisitions, isLoading, error } = useGetAcquisitionsAcquisitionsGet()
   const navigate = useNavigate()
 

--- a/apps/legacy/src/routes/models.$modelName.grids.$gridId.weights.tsx
+++ b/apps/legacy/src/routes/models.$modelName.grids.$gridId.weights.tsx
@@ -2,16 +2,16 @@ import { Container, ThemeProvider } from '@mui/material'
 import type { QualityPredictionModelWeight } from '@smartem/api'
 import { apiUrl } from '@smartem/api'
 import { createFileRoute } from '@tanstack/react-router'
-import React from 'react'
+import { useEffect, useState } from 'react'
 import { Navbar } from '../components/navbar'
 import { theme } from '../components/theme'
 import { TimeSeriesChart } from '../components/timeseries'
 
 function PredictionModelWeights() {
   const { modelName, gridId } = Route.useParams()
-  const [result, setResult] = React.useState<QualityPredictionModelWeight[] | null>(null)
+  const [result, setResult] = useState<QualityPredictionModelWeight[] | null>(null)
 
-  React.useEffect(() => {
+  useEffect(() => {
     const fetchData = async () => {
       const models = await fetch(
         `${apiUrl()}/prediction_models/${modelName}/grids/${gridId}/weights`

--- a/apps/smartem/package.json
+++ b/apps/smartem/package.json
@@ -16,7 +16,7 @@
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
     "@mui/material": "^7.0.2",
-    "@tanstack/react-query": "^5.95.2",
+    "@tanstack/react-query": "^5.100.6",
     "@tanstack/react-router": "^1.168.3",
     "@tanstack/router-devtools": "^1.166.11",
     "react": "^19.2.4",
@@ -24,6 +24,7 @@
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.2.2",
+    "@tanstack/react-query-devtools": "^5.100.6",
     "@tanstack/router-cli": "^1.166.18",
     "@tanstack/router-vite-plugin": "^1.166.19",
     "@types/node": "^25",

--- a/apps/smartem/src/routes/__root.tsx
+++ b/apps/smartem/src/routes/__root.tsx
@@ -1,6 +1,7 @@
 import { Box, CssBaseline } from '@mui/material'
 import { ThemeProvider } from '@mui/material/styles'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import { createRootRoute, Outlet } from '@tanstack/react-router'
 import { TanStackRouterDevtools } from '@tanstack/router-devtools'
 import { Header } from '~/components/shell/Header'
@@ -31,6 +32,7 @@ function RootComponent() {
           </Box>
         </Box>
         <TanStackRouterDevtools />
+        {import.meta.env.DEV && <ReactQueryDevtools initialIsOpen={false} />}
       </QueryClientProvider>
     </ThemeProvider>
   )

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@mui/material": "^7.0.2",
         "@mui/x-charts": "^8.28.0",
         "@smartem/api": "*",
-        "@tanstack/react-query": "^5.95.2",
+        "@tanstack/react-query": "^5.100.6",
         "@tanstack/react-router": "^1.168.3",
         "@tanstack/router-devtools": "^1.166.11",
         "boring-avatars": "^2.0.4",
@@ -39,6 +39,7 @@
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.2.2",
+        "@tanstack/react-query-devtools": "^5.100.6",
         "@tanstack/router-cli": "^1.166.18",
         "@tanstack/router-vite-plugin": "^1.166.19",
         "@types/d3-array": "^3.2.1",
@@ -51,6 +52,50 @@
         "vite-tsconfig-paths": "^6.1.0"
       }
     },
+    "apps/legacy/node_modules/@tanstack/query-core": {
+      "version": "5.100.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.6.tgz",
+      "integrity": "sha512-Os2CPUr98to98RYm+D4qGqGkiffn7MGSyl2547a4MljVkHE30AMJRqTiyCqBfMwzAx/I91vCkAxp5tHSla6Twg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "apps/legacy/node_modules/@tanstack/react-query": {
+      "version": "5.100.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.6.tgz",
+      "integrity": "sha512-uVSrps0PV16Cxmcn2rvL+dUhwTpTUtiRW347AEeYxMZXO2pZe9ja7E24PAMGoQ5u2g89DD8u4QhOviBk+RN8RA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.100.6"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "apps/legacy/node_modules/@tanstack/react-query-devtools": {
+      "version": "5.100.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.100.6.tgz",
+      "integrity": "sha512-sz3ksMKA2t1rx0+Odzb0x1A3pXH/SVf7fzlzd3sKXzwXz8980f5sbOwfQD6+UfTG8G4Y2KaIg9e3sBn+uC4VTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.100.6"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.100.6",
+        "react": "^18 || ^19"
+      }
+    },
     "apps/smartem": {
       "name": "@smartem/app",
       "dependencies": {
@@ -59,7 +104,7 @@
         "@mui/material": "^7.0.2",
         "@smartem/api": "*",
         "@smartem/ui": "*",
-        "@tanstack/react-query": "^5.95.2",
+        "@tanstack/react-query": "^5.100.6",
         "@tanstack/react-router": "^1.168.3",
         "@tanstack/router-devtools": "^1.166.11",
         "react": "^19.2.4",
@@ -67,6 +112,7 @@
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.2.2",
+        "@tanstack/react-query-devtools": "^5.100.6",
         "@tanstack/router-cli": "^1.166.18",
         "@tanstack/router-vite-plugin": "^1.166.19",
         "@types/node": "^25",
@@ -76,6 +122,50 @@
         "tailwindcss": "^4.0.0",
         "vite": "^8.0.2",
         "vite-tsconfig-paths": "^6.1.0"
+      }
+    },
+    "apps/smartem/node_modules/@tanstack/query-core": {
+      "version": "5.100.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.6.tgz",
+      "integrity": "sha512-Os2CPUr98to98RYm+D4qGqGkiffn7MGSyl2547a4MljVkHE30AMJRqTiyCqBfMwzAx/I91vCkAxp5tHSla6Twg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "apps/smartem/node_modules/@tanstack/react-query": {
+      "version": "5.100.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.6.tgz",
+      "integrity": "sha512-uVSrps0PV16Cxmcn2rvL+dUhwTpTUtiRW347AEeYxMZXO2pZe9ja7E24PAMGoQ5u2g89DD8u4QhOviBk+RN8RA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.100.6"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "apps/smartem/node_modules/@tanstack/react-query-devtools": {
+      "version": "5.100.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.100.6.tgz",
+      "integrity": "sha512-sz3ksMKA2t1rx0+Odzb0x1A3pXH/SVf7fzlzd3sKXzwXz8980f5sbOwfQD6+UfTG8G4Y2KaIg9e3sBn+uC4VTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.100.6"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.100.6",
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2661,30 +2751,15 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
-    "node_modules/@tanstack/query-core": {
-      "version": "5.99.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.99.2.tgz",
-      "integrity": "sha512-1HunU0bXVsR1ZJMZbcOPE6VtaBJxsW809RE9xPe4Gz7MlB0GWwQvuTPhMoEmQ/hIzFKJ/DWAuttIe7BOaWx0tA==",
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.100.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.100.6.tgz",
+      "integrity": "sha512-2SiNwlOiAdTbqktCSmwlXZH8x8mckSbES2O0bdr3qZNhdQl5DCtImZx0S3HGeNHWTIkzTaHx2Isg+bD4M3WRIg==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
-      }
-    },
-    "node_modules/@tanstack/react-query": {
-      "version": "5.99.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.99.2.tgz",
-      "integrity": "sha512-vM91UEe45QUS9ED6OklsVL15i8qKcRqNwpWzPTVWvRPRSEgDudDgHpvyTjcdlwHcrKNa80T+xXYcchT2noPnZA==",
-      "license": "MIT",
-      "dependencies": {
-        "@tanstack/query-core": "5.99.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "react": "^18 || ^19"
       }
     },
     "node_modules/@tanstack/react-router": {
@@ -7003,7 +7078,7 @@
     "packages/api": {
       "name": "@smartem/api",
       "dependencies": {
-        "@tanstack/react-query": "^5.95.2",
+        "@tanstack/react-query": "^5.100.6",
         "axios": "^1.15.0"
       },
       "devDependencies": {
@@ -7013,6 +7088,32 @@
       },
       "peerDependencies": {
         "react": "^19.0.0"
+      }
+    },
+    "packages/api/node_modules/@tanstack/query-core": {
+      "version": "5.100.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.6.tgz",
+      "integrity": "sha512-Os2CPUr98to98RYm+D4qGqGkiffn7MGSyl2547a4MljVkHE30AMJRqTiyCqBfMwzAx/I91vCkAxp5tHSla6Twg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "packages/api/node_modules/@tanstack/react-query": {
+      "version": "5.100.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.6.tgz",
+      "integrity": "sha512-uVSrps0PV16Cxmcn2rvL+dUhwTpTUtiRW347AEeYxMZXO2pZe9ja7E24PAMGoQ5u2g89DD8u4QhOviBk+RN8RA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.100.6"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "packages/ui": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "axios": "^1.15.0",
-    "@tanstack/react-query": "^5.95.2"
+    "@tanstack/react-query": "^5.100.6"
   },
   "devDependencies": {
     "@faker-js/faker": "^10.4.0",

--- a/packages/api/src/mutator.ts
+++ b/packages/api/src/mutator.ts
@@ -37,18 +37,19 @@ AXIOS_INSTANCE.interceptors.response.use(
   }
 )
 
+type CancellablePromise<T> = Promise<T> & { cancel: () => void }
+
 export const customInstance = <T>(
   config: AxiosRequestConfig,
   options?: AxiosRequestConfig
-): Promise<T> => {
+): CancellablePromise<T> => {
   const source = Axios.CancelToken.source()
   const promise = AXIOS_INSTANCE({
     ...config,
     ...options,
     cancelToken: source.token,
-  }).then(({ data }) => data)
+  }).then(({ data }) => data) as CancellablePromise<T>
 
-  // @ts-expect-error
   promise.cancel = () => {
     source.cancel('Query was cancelled')
   }


### PR DESCRIPTION
## Summary

Three independent easy-win items from the Frontend Improvement Roadmap (#39), bundled because each is small and reviewable on its own commit.

- **fix(api):** replace `@ts-expect-error` in `packages/api/src/mutator.ts` with a typed `CancellablePromise<T>` intersection. (#39 Tier 1: Fix TypeScript Suppressions)
- **chore(frontend):** install `@tanstack/react-query-devtools` and mount it in both apps' root route behind `import.meta.env.DEV`. Bumped `@tanstack/react-query` to `^5.100.6` across `apps/smartem`, `apps/legacy` and `packages/api` so the workspace resolves a single instance — the devtools peer dependency would otherwise have split it. (#39 Tier 2: Add TanStack Query DevTools)
- **refactor(legacy):** drop `React.` namespace from hook calls across `apps/legacy/src` (~86 occurrences). Biome's safe fix correctly split type-only `React` imports into `import type React` and left the one file using `<React.Fragment>` as JSX with a value import. `apps/smartem/src` already followed the named-import style. (#39 Tier 2: Remove React Namespace from Hooks)

Each item lives in its own commit so the PR can be reviewed (or split, or partially reverted) along those lines.

## Test plan

- [x] `npm run typecheck` (both workspaces) passes
- [x] `npm run check` (Biome lint + format) passes — only the pre-existing `biome.json` schema-version info remains
- [x] Pre-push hooks (typecheck, lint, format-check, gitleaks) green
- [ ] Smoke-check `npm run dev` and `npm run dev:smartem` — confirm the React Query Devtools panel button appears in dev only
- [ ] Confirm the Fragment-using route (`/acquisitions/$acqId/grids/$gridId`) still renders correctly

Closes none on its own — ticks several checkboxes in #39.