### PR TITLE
fix(deps): bump axios and fast-uri to clear 4 security alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3405,9 +3405,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
-      "integrity": "sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
@@ -4212,9 +4212,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary
Lockfile-only bumps to clear four open code-scanning alerts:

| Alert | Package | From | To | CVE |
|-------|---------|------|----|----|
| [#25](https://github.com/DiamondLightSource/smartem-frontend/security/code-scanning/25) | axios | 1.15.1 | 1.15.2 | CVE-2026-42044 (prototype pollution via `parseReviver`) |
| [#26](https://github.com/DiamondLightSource/smartem-frontend/security/code-scanning/26) | axios | 1.15.1 | 1.15.2 | CVE-2026-42264 (prototype pollution in HTTP adapter) |
| [#27](https://github.com/DiamondLightSource/smartem-frontend/security/code-scanning/27) | fast-uri | 3.1.0 | 3.1.2 | CVE-2026-6321 (path traversal via percent-encoded dot segments) |
| [#28](https://github.com/DiamondLightSource/smartem-frontend/security/code-scanning/28) | fast-uri | 3.1.0 | 3.1.2 | CVE-2026-6322 |

Both are transitive:
- `axios` via `@smartem/api`
- `fast-uri` via `orval` → `@scalar/openapi-parser` → `ajv`

The existing `^1.15.0` constraint on `axios` in `packages/api/package.json` is unchanged — only the resolved lockfile entry is bumped to the minimum fix version. `fast-uri` has no direct constraint.

## Test plan
- [x] `npm audit` reports 0 vulnerabilities after the bump
- [x] `npm install --package-lock-only` re-resolves cleanly with no further changes
- [x] Diff confirmed: only `package-lock.json` touched (6 lines)
- [x] CI passes