### PR TITLE
fix(docker): unblock release build on main

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,12 @@ COPY apps/smartem/package.json apps/smartem/
 COPY apps/legacy/package.json apps/legacy/
 COPY packages/api/package.json packages/api/
 COPY packages/ui/package.json packages/ui/
-RUN npm ci
+RUN npm ci --ignore-scripts
 
 COPY apps/smartem apps/smartem
 COPY packages packages
 COPY scripts scripts
-COPY tsconfig.base.json tsconfig.json biome.json ./
+COPY tsconfig.base.json tsconfig.json ./
 
 ARG FRONTEND_VERSION=dev
 ARG GIT_SHA=unknown


### PR DESCRIPTION
## Summary

The release pipeline added in #90 failed on its first run on `main` ([workflow run 26216162630](https://github.com/DiamondLightSource/smartem-frontend/actions/runs/26216162630)). Two issues in the Dockerfile, both stemming from differences between local dev and the alpine build container:

1. **`biome.json` COPY vs `.dockerignore` conflict.** The Dockerfile did `COPY tsconfig.base.json tsconfig.json biome.json ./`, but `.dockerignore` excludes `biome.json`. Buildx fails at the cache-key checksum stage with `"/biome.json": not found` before any RUN executes. `biome.json` is only consumed by the dedicated lint job — never inside the image — so the cleanest fix is to drop it from the COPY list. The `.dockerignore` entry stays correct: dev tooling shouldn't be in the build context.

2. **`npm ci` runs root `prepare: lefthook install`, which needs `git`.** `node:22-alpine` ships without `git`, so the install fails with `exec: "git": executable file not found`. The PR author tested `npm ci` locally where git is on PATH, so this wasn't visible in pre-merge verification. The `prepare` script only wires git hooks for local dev — no purpose in a production image — so `--ignore-scripts` is the right boundary. No workspace package has its own `prepare`/`postinstall`/`preinstall`, so nothing legitimate is skipped.

The first failure masked the second in CI; once `biome.json` is fixed, the `npm ci` step would have failed next. Fixing both in one go.

## Local verification

- `docker build -t smartem-frontend-test .` — succeeds end-to-end (api:generate, write-version-json, build:smartem all run, final nginx stage exports cleanly)
- `docker run --rm -d -p 18080:80 smartem-frontend-test`:
  - `GET /` → 200 (index.html)
  - `GET /some/nonexistent/route` → 200 (history-mode fallback works)
  - `GET /version` → 200 (version.json alias works)

## Test plan

- [x] `Release smartem-frontend` workflow passes on this PR's `pull_request` trigger (lint + build)
- [ ] After merge, the `main`-push run completes the `Publish container to GHCR` and `Create GitHub Release` jobs, producing `ghcr.io/diamondlightsource/smartem-frontend:0.1.0rc{n}`