### PR TITLE
feat(config): runtime config + nginx /api proxy for k8s deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,9 @@ RUN npm run build:smartem
 
 FROM nginx:1.30-alpine
 RUN rm /etc/nginx/conf.d/default.conf
-COPY apps/smartem/nginx.conf /etc/nginx/conf.d/default.conf
+COPY apps/smartem/nginx.conf /etc/nginx/templates/default.conf.template
+ENV BACKEND_HOST=smartem-http-api-service \
+    NGINX_ENTRYPOINT_LOCAL_RESOLVERS=1 \
+    NGINX_ENVSUBST_FILTER='^(BACKEND_HOST|NGINX_LOCAL_RESOLVERS)$'
 COPY --from=build /app/apps/smartem/dist /usr/share/nginx/html
 EXPOSE 80

--- a/apps/smartem/.env.example
+++ b/apps/smartem/.env.example
@@ -1,4 +1,8 @@
-VITE_KEYCLOAK_URL=https://identity-test.diamond.ac.uk
-VITE_KEYCLOAK_REALM=dls
-VITE_KEYCLOAK_CLIENT_ID=SmartEM_User
-VITE_AUTH_ENABLED=false
+# Runtime config (Keycloak URL/realm/clientId, authEnabled) lives in
+# apps/smartem/public/config.json - fetched at SPA boot. In production
+# deployments the file is overridden by a k8s ConfigMap mount; for local
+# `npm run dev:smartem` edit public/config.json directly.
+
+# Toggle MSW request mocking for local dev only. Must be set at build time
+# because MSW is bundled conditionally.
+# VITE_ENABLE_MOCKS=true

--- a/apps/smartem/nginx.conf
+++ b/apps/smartem/nginx.conf
@@ -6,6 +6,12 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Defer upstream DNS resolution to request time so the container can start
+    # even if BACKEND_HOST isn't reachable yet (e.g. backend pod scheduling).
+    # NGINX_LOCAL_RESOLVERS is exported by the nginx image's
+    # 15-local-resolvers.envsh entrypoint from /etc/resolv.conf.
+    resolver ${NGINX_LOCAL_RESOLVERS} valid=30s;
+
     location /assets/ {
         expires 1y;
         add_header Cache-Control "public, immutable";
@@ -14,6 +20,20 @@ server {
     location = /version {
         default_type application/json;
         alias /usr/share/nginx/html/version.json;
+    }
+
+    location = /config.json {
+        default_type application/json;
+        try_files $uri =404;
+    }
+
+    location /api/ {
+        set $backend_upstream "${BACKEND_HOST}";
+        proxy_pass http://$backend_upstream/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 
     location / {

--- a/apps/smartem/package.json
+++ b/apps/smartem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartem/app",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/smartem/public/config.json
+++ b/apps/smartem/public/config.json
@@ -1,0 +1,8 @@
+{
+  "keycloak": {
+    "url": "http://localhost:30090",
+    "realm": "dls",
+    "clientId": "SmartEM_User"
+  },
+  "authEnabled": false
+}

--- a/apps/smartem/src/auth/AuthProvider.tsx
+++ b/apps/smartem/src/auth/AuthProvider.tsx
@@ -7,7 +7,7 @@ import {
   useRef,
   useState,
 } from 'react'
-import { keycloakConfig } from './config'
+import { getKeycloakConfig } from './config'
 import type { Auth, AuthUser } from './types'
 
 const MIN_SECONDS_BEFORE_EXPIRY = 10
@@ -58,7 +58,7 @@ export const AuthProvider = ({ children, onTokenChange }: AuthProviderProps) => 
   onTokenChangeRef.current = onTokenChange
 
   useEffect(() => {
-    const keycloak = new Keycloak(keycloakConfig)
+    const keycloak = new Keycloak(getKeycloakConfig())
 
     const emitToken = () => {
       const token = keycloak.authenticated && keycloak.token ? keycloak.token : ''

--- a/apps/smartem/src/auth/config.ts
+++ b/apps/smartem/src/auth/config.ts
@@ -1,14 +1,25 @@
 import type { KeycloakServerConfig } from 'keycloak-js'
 
-export const isAuthEnabled = (): boolean => {
-  if (import.meta.env.VITE_ENABLE_MOCKS === 'true') {
-    return import.meta.env.VITE_AUTH_ENABLED === 'true'
-  }
-  return import.meta.env.VITE_AUTH_ENABLED !== 'false'
+export interface RuntimeConfig {
+  keycloak: KeycloakServerConfig
+  authEnabled: boolean
 }
 
-export const keycloakConfig: KeycloakServerConfig = {
-  url: import.meta.env.VITE_KEYCLOAK_URL || 'https://identity.diamond.ac.uk',
-  realm: import.meta.env.VITE_KEYCLOAK_REALM || 'dls',
-  clientId: import.meta.env.VITE_KEYCLOAK_CLIENT_ID || 'SmartEM_User',
+let runtimeConfig: RuntimeConfig | null = null
+
+export const setRuntimeConfig = (config: RuntimeConfig): void => {
+  runtimeConfig = config
 }
+
+const getRuntimeConfig = (): RuntimeConfig => {
+  if (!runtimeConfig) {
+    throw new Error(
+      'Runtime config not loaded. /config.json must be fetched and applied before reading auth config.'
+    )
+  }
+  return runtimeConfig
+}
+
+export const isAuthEnabled = (): boolean => getRuntimeConfig().authEnabled
+
+export const getKeycloakConfig = (): KeycloakServerConfig => getRuntimeConfig().keycloak

--- a/apps/smartem/src/auth/index.ts
+++ b/apps/smartem/src/auth/index.ts
@@ -1,3 +1,5 @@
 export { AuthGate } from './AuthGate'
 export { AuthProvider, useAuth } from './AuthProvider'
+export type { RuntimeConfig } from './config'
+export { setRuntimeConfig } from './config'
 export type { Auth, AuthUser } from './types'

--- a/apps/smartem/src/main.tsx
+++ b/apps/smartem/src/main.tsx
@@ -1,7 +1,7 @@
 import { createRouter, RouterProvider } from '@tanstack/react-router'
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import { AuthGate } from './auth'
+import { AuthGate, type RuntimeConfig, setRuntimeConfig } from './auth'
 import { routeTree } from './routeTree.gen'
 import './app.css'
 
@@ -13,28 +13,43 @@ declare module '@tanstack/react-router' {
   }
 }
 
-async function enableMocking() {
+async function loadRuntimeConfig(): Promise<void> {
+  const response = await fetch('/config.json', { cache: 'no-store' })
+  if (!response.ok) {
+    throw new Error(`Failed to load /config.json: ${response.status} ${response.statusText}`)
+  }
+  const config = (await response.json()) as RuntimeConfig
+  setRuntimeConfig(config)
+}
+
+async function enableMocking(): Promise<void> {
   if (import.meta.env.VITE_ENABLE_MOCKS !== 'true') {
     return
   }
 
   const { worker } = await import('./mocks/browser')
 
-  return worker.start({
+  await worker.start({
     onUnhandledRequest: 'warn',
   })
 }
 
 const rootElement = document.getElementById('root')
 if (rootElement && !rootElement.innerHTML) {
-  enableMocking().then(() => {
-    const root = createRoot(rootElement)
-    root.render(
-      <StrictMode>
-        <AuthGate>
-          <RouterProvider router={router} />
-        </AuthGate>
-      </StrictMode>
-    )
-  })
+  loadRuntimeConfig()
+    .then(() => enableMocking())
+    .then(() => {
+      const root = createRoot(rootElement)
+      root.render(
+        <StrictMode>
+          <AuthGate>
+            <RouterProvider router={router} />
+          </AuthGate>
+        </StrictMode>
+      )
+    })
+    .catch((err) => {
+      console.error('App boot failed:', err)
+      rootElement.innerHTML = `<pre style="padding:24px;font-family:system-ui;color:#b91c1c">Failed to start SmartEM: ${err instanceof Error ? err.message : String(err)}</pre>`
+    })
 }

--- a/apps/smartem/src/version.ts
+++ b/apps/smartem/src/version.ts
@@ -1,3 +1,3 @@
 // Must stay in sync with the version field in apps/smartem/package.json.
 // The release workflow validates the two values match before building.
-export const FRONTEND_VERSION = '0.1.0' as const
+export const FRONTEND_VERSION = '0.2.0' as const

--- a/packages/api/src/mutator.ts
+++ b/packages/api/src/mutator.ts
@@ -1,14 +1,7 @@
 import type { AxiosError, AxiosRequestConfig } from 'axios'
 import Axios from 'axios'
 
-export const apiUrl = () => {
-  // In development, use the Vite proxy to avoid CORS issues
-  // In production, use the configured API endpoint or default to localhost
-  if (import.meta.env.DEV) {
-    return '/api'
-  }
-  return import.meta.env.VITE_API_ENDPOINT || 'http://localhost:8000'
-}
+export const apiUrl = () => '/api'
 
 export const AXIOS_INSTANCE = Axios.create({
   baseURL: apiUrl(),


### PR DESCRIPTION
## Summary

Phase A of the smartem-frontend k8s deploy work (see prior PRs #74, #90, #91, #92, #93). Makes the SPA image deployable across environments without per-env rebuilds.

The released `0.1.0` image baked `VITE_KEYCLOAK_*` and `VITE_API_ENDPOINT` at build time, which meant the published bundle couldn't talk to a backend or Keycloak from k8s without rebuilding per environment. Two coupled changes solve both:

1. **Backend API moves to relative `/api/` proxied by nginx.** `mutator.ts` now always returns `/api`. The Dockerfile's nginx stage adds `location /api/` that `proxy_pass`es to `${BACKEND_HOST}` via a variable + `resolver`, so the container starts even if the backend isn't ready yet and DNS resolution happens at request time. `BACKEND_HOST` defaults to `smartem-http-api-service` (the k8s service name). The vite dev server's existing `/api` proxy keeps working unchanged.

2. **Keycloak URL/realm/clientId and `authEnabled` move to runtime `/config.json`.** `main.tsx` fetches `/config.json` before render, calls `setRuntimeConfig()`, then mounts `AuthGate`. `auth/config.ts` exposes `getKeycloakConfig()` and `isAuthEnabled()` backed by the loaded config (throws if read before load). The image ships a placeholder `apps/smartem/public/config.json` with dev defaults (Keycloak mock at `localhost:30090`, `authEnabled: false`); k8s ConfigMap mounts the per-environment file at `/usr/share/nginx/html/config.json`.

Other touches:

- **Dockerfile**: copy `nginx.conf` as a template under `/etc/nginx/templates/` so the `nginx:alpine` entrypoint runs `envsubst` on it. `NGINX_ENTRYPOINT_LOCAL_RESOLVERS=1` makes the image's `15-local-resolvers.envsh` export the pod's resolver(s) into `NGINX_LOCAL_RESOLVERS`, and `NGINX_ENVSUBST_FILTER` scopes the substitution to just `BACKEND_HOST` and `NGINX_LOCAL_RESOLVERS` (so any `$host`/`$remote_addr` in the template stays as nginx vars, never accidentally substituted).
- **`.env.example`**: drop the now-runtime `VITE_KEYCLOAK_*` / `VITE_AUTH_ENABLED`; document where to edit them for local dev (`public/config.json`).
- **Version bump to `0.2.0`** in both `apps/smartem/package.json` and `apps/smartem/src/version.ts`. The release pipeline will tag `smartem-frontend-v0.2.0` after merge.

Skipped on purpose:

- No regeneration of `packages/api/src/generated/**`. The release workflow regenerates these at build time; the same OpenAPI spec yielded only orval-version-comment + timestamp churn. Out of scope.
- Smartem-frontend#93 (`version-check.ts` wiring) is independent; not bundled here.

## Local verification

- `npm ci`, `npm run typecheck`, `npm run check`, `npm run build:smartem` all clean
- `docker build .` succeeds end-to-end
- Container starts with default (unreachable) `BACKEND_HOST` and serves `/`, `/version`, `/config.json`, SPA history fallback
- `docker run -v /tmp/x.json:/usr/share/nginx/html/config.json` proves the ConfigMap-mount pattern overrides the placeholder
- On a docker network with a stand-in backend, `GET /api/` reverse-proxies through and returns the backend's response (verified with a local `nginx:alpine` mock)
- Confirmed the substituted `default.conf` (inside the running container) has the correct `resolver` line and `set $backend_upstream "smartem-http-api-service"` directive

## Follow-ups (Phase B, smartem-devtools)

Once this lands and `0.2.0` is on GHCR, the k8s manifests + ingress for the frontend can land in smartem-devtools (deployment+service per env, ConfigMap with per-env keycloak/auth values, kustomization updates). That's the next PR in this series.

## Test plan

- [ ] CI lint + typecheck + build pass
- [ ] After merge, the release workflow produces `ghcr.io/diamondlightsource/smartem-frontend:0.2.0rc{n}` and `:latest` is unchanged (RC, not stable)
- [ ] Tag `smartem-frontend-v0.2.0` to produce the stable release once Phase B is ready to consume it