### PR TITLE
fix(nginx): strip /api/ prefix when proxying via variable upstream

### DIFF
--- a/apps/smartem/nginx.conf
+++ b/apps/smartem/nginx.conf
@@ -29,7 +29,11 @@ server {
 
     location /api/ {
         set $backend_upstream "${BACKEND_HOST}";
-        proxy_pass http://$backend_upstream/;
+        # When proxy_pass uses a variable, nginx does NOT rewrite the URI
+        # regardless of a trailing slash, so the /api/ prefix would leak
+        # through to the upstream. Strip it explicitly with rewrite.
+        rewrite ^/api/(.*) /$1 break;
+        proxy_pass http://$backend_upstream;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## Summary

When `proxy_pass` uses a variable (`set $backend_upstream "${BACKEND_HOST}";`), nginx does **not** rewrite the request URI regardless of a trailing slash on the `proxy_pass` value. The previous template:

```nginx
location /api/ {
    set $backend_upstream "${BACKEND_HOST}";
    proxy_pass http://$backend_upstream/;
    ...
}
```

forwarded `/api/foo` to the backend as `/api/foo` (instead of `/foo`), which 404'd because the backend mounts its routes at `/`.

Fix: add an explicit `rewrite ^/api/(.*) /$1 break;` to strip the prefix, and drop the trailing slash from `proxy_pass` (no longer load-bearing with the rewrite, and it was never doing what it looked like it was).

## Where this surfaced

In smartem-devtools#205 (k3s dev deploy of this image at NodePort 30100). The workaround there is an in-cluster ConfigMap override of `default.conf.template`; once this lands and a new `smartem-frontend` image ships, that ConfigMap can be deleted and the devtools manifests revert to the in-image template.

## Test plan

- [x] CI passes (Docker build, typecheck, format-check)
- [ ] After image release: redeploy the dev k8s frontend pod against the new image (without the ConfigMap workaround) and confirm `curl http://localhost:30100/api/acquisitions` (with Bearer) returns 200 from the backend, not 404