### PR TITLE
fix(nginx): 404 missing static assets instead of SPA fallback

### DIFF
--- a/apps/smartem/nginx.conf
+++ b/apps/smartem/nginx.conf
@@ -12,7 +12,9 @@ server {
     # 15-local-resolvers.envsh entrypoint from /etc/resolv.conf.
     resolver ${NGINX_LOCAL_RESOLVERS} valid=30s;
 
-    location /assets/ {
+    # ^~ prevents the static-asset regex below from overriding this block
+    # for hashed bundles under /assets/ - they must keep the immutable cache headers.
+    location ^~ /assets/ {
         expires 1y;
         add_header Cache-Control "public, immutable";
     }
@@ -38,6 +40,14 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Missing static assets should 404 rather than fall back to index.html.
+    # The catch-all below is the SPA history-mode fallback for client-side
+    # routes; without this block, a request for /favicon-missing.png would
+    # return HTTP 200 with the SPA HTML body, masking broken references.
+    location ~* \.(png|jpg|jpeg|gif|svg|ico|webp|avif|woff|woff2|ttf|eot|map|txt|xml|json|webmanifest)$ {
+        try_files $uri =404;
     }
 
     location / {


### PR DESCRIPTION
## Summary
- Add a regex `location` matching common static-asset extensions that returns a real 404 instead of falling through to the SPA `index.html`. Placed before the catch-all so client-side routes still get the history-mode fallback.
- Add `^~` to the `/assets/` prefix so the new regex cannot override its `expires 1y` / `immutable` cache headers on hashed bundles.

Closes #92.

## Test plan

Verified locally by bind-mounting the new `nginx.conf` over the template in `ghcr.io/diamondlightsource/smartem-frontend:0.2.0` and curling.

- [x] `GET /favicon-missing.png` → 404 (was 200 text/html)
- [x] `GET /robots-missing.txt`, `/site.webmanifest`, `/missing-font.woff2`, `/sourcemap-missing.map`, `/missing.json` → 404
- [x] `GET /favicon.png`, `/diamond-logo.ico`, `/fragment-screen-logo.png` → 200 with correct content-type
- [x] `GET /config.json` → 200 application/json (exact-match block still wins)
- [x] `GET /version` → 200 application/json (alias still works)
- [x] `GET /not-a-real-page`, `/sessions/123`, `/models`, `/grids/abc/squares` → 200 text/html (SPA fallback preserved)
- [x] `GET /assets/<hashed-bundle>.js` → 200 with `Cache-Control: public, immutable` and `max-age=31536000` (regression-protected by the `^~` modifier)
- [x] `GET /assets/nonexistent.js` → 404