### PR TITLE
chore(release): bump version to 0.2.2

### DIFF
--- a/apps/smartem/package.json
+++ b/apps/smartem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartem/app",
-  "version": "0.2.0",
+  "version": "0.2.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/smartem/src/version.ts
+++ b/apps/smartem/src/version.ts
@@ -1,3 +1,3 @@
 // Must stay in sync with the version field in apps/smartem/package.json.
 // The release workflow validates the two values match before building.
-export const FRONTEND_VERSION = '0.2.0' as const
+export const FRONTEND_VERSION = '0.2.2' as const


### PR DESCRIPTION
## Summary

Bump the frontend version to 0.2.2 in both `apps/smartem/package.json` and `apps/smartem/src/version.ts` (release workflow validates these two stay in sync).

Includes two unreleased changes since v0.2.1:
- `feat(smartem)`: add /models heatmap matrix with mock weights data
- `fix(nginx)`: 404 missing static assets instead of SPA fallback

## Background

v0.2.0 and v0.2.1 both shipped with the in-bundle `FRONTEND_VERSION` still at `0.2.0`. The release pipeline reads the image tag from the git tag, but the UI reports `FRONTEND_VERSION` from the compiled bundle, so users saw `0.2.0` even on the v0.2.1 image. Bumping both files together so the v0.2.2 image will report the correct runtime version.

## Test plan

- [x] Pre-commit hooks (biome-check) pass
- [ ] CI green on PR
- [ ] After merge, tag `smartem-frontend-v0.2.2` triggers the release pipeline and produces a new image