### PR TITLE
feat(auth): always-on UI auth with MockAuthProvider for mock mode

### DIFF
--- a/apps/smartem/.env.example
+++ b/apps/smartem/.env.example
@@ -1,8 +1,9 @@
-# Runtime config (Keycloak URL/realm/clientId, authEnabled) lives in
+# Runtime config (Keycloak URL/realm/clientId) lives in
 # apps/smartem/public/config.json - fetched at SPA boot. In production
 # deployments the file is overridden by a k8s ConfigMap mount; for local
 # `npm run dev:smartem` edit public/config.json directly.
 
 # Toggle MSW request mocking for local dev only. Must be set at build time
-# because MSW is bundled conditionally.
+# because MSW is bundled conditionally. Mock mode also short-circuits the
+# /config.json fetch and uses MockAuthProvider in place of Keycloak.
 # VITE_ENABLE_MOCKS=true

--- a/apps/smartem/public/config.json
+++ b/apps/smartem/public/config.json
@@ -3,6 +3,5 @@
     "url": "http://localhost:30090",
     "realm": "dls",
     "clientId": "SmartEM_User"
-  },
-  "authEnabled": false
+  }
 }

--- a/apps/smartem/src/auth/AuthContext.ts
+++ b/apps/smartem/src/auth/AuthContext.ts
@@ -1,0 +1,14 @@
+import { createContext, useContext } from 'react'
+import type { Auth } from './types'
+
+export const defaultAuth: Auth = {
+  initialised: false,
+  authenticated: false,
+  login: () => {},
+  logout: () => {},
+  getToken: () => '',
+}
+
+export const AuthContext = createContext<Auth>(defaultAuth)
+
+export const useAuth = () => useContext(AuthContext)

--- a/apps/smartem/src/auth/AuthGate.tsx
+++ b/apps/smartem/src/auth/AuthGate.tsx
@@ -2,18 +2,19 @@ import { Login } from '@mui/icons-material'
 import { Box, Button, Typography } from '@mui/material'
 import { setAuthToken } from '@smartem/api'
 import type { PropsWithChildren } from 'react'
-import { AuthProvider, useAuth } from './AuthProvider'
-import { isAuthEnabled } from './config'
+import { useAuth } from './AuthContext'
+import { KeycloakAuthProvider } from './KeycloakAuthProvider'
+import { MockAuthProvider } from './MockAuthProvider'
 
 export const AuthGate = ({ children }: PropsWithChildren) => {
-  if (!isAuthEnabled()) {
-    return <>{children}</>
+  if (import.meta.env.VITE_ENABLE_MOCKS === 'true') {
+    return <MockAuthProvider onTokenChange={setAuthToken}>{children}</MockAuthProvider>
   }
 
   return (
-    <AuthProvider onTokenChange={setAuthToken}>
+    <KeycloakAuthProvider onTokenChange={setAuthToken}>
       <AuthBoundary>{children}</AuthBoundary>
-    </AuthProvider>
+    </KeycloakAuthProvider>
   )
 }
 

--- a/apps/smartem/src/auth/KeycloakAuthProvider.tsx
+++ b/apps/smartem/src/auth/KeycloakAuthProvider.tsx
@@ -1,31 +1,13 @@
 import Keycloak, { type KeycloakError } from 'keycloak-js'
-import {
-  createContext,
-  type PropsWithChildren,
-  useContext,
-  useEffect,
-  useRef,
-  useState,
-} from 'react'
+import { type PropsWithChildren, useEffect, useRef, useState } from 'react'
+import { AuthContext, defaultAuth } from './AuthContext'
 import { getKeycloakConfig } from './config'
 import type { Auth, AuthUser } from './types'
 
 const MIN_SECONDS_BEFORE_EXPIRY = 10
 const MIN_REFRESH_INTERVAL_SECONDS = 5
 
-const defaultAuth: Auth = {
-  initialised: false,
-  authenticated: false,
-  login: () => {},
-  logout: () => {},
-  getToken: () => '',
-}
-
-const AuthContext = createContext<Auth>(defaultAuth)
-
-export const useAuth = () => useContext(AuthContext)
-
-interface AuthProviderProps extends PropsWithChildren {
+interface KeycloakAuthProviderProps extends PropsWithChildren {
   onTokenChange?: (token: string) => void
 }
 
@@ -51,7 +33,7 @@ function buildAuth(keycloak: Keycloak): Auth {
   return auth
 }
 
-export const AuthProvider = ({ children, onTokenChange }: AuthProviderProps) => {
+export const KeycloakAuthProvider = ({ children, onTokenChange }: KeycloakAuthProviderProps) => {
   const [auth, setAuth] = useState<Auth>(defaultAuth)
   const refreshTimer = useRef<ReturnType<typeof setTimeout>>(undefined)
   const onTokenChangeRef = useRef(onTokenChange)

--- a/apps/smartem/src/auth/MockAuthProvider.tsx
+++ b/apps/smartem/src/auth/MockAuthProvider.tsx
@@ -1,0 +1,32 @@
+import { type PropsWithChildren, useEffect } from 'react'
+import { AuthContext } from './AuthContext'
+import type { Auth } from './types'
+
+const MOCK_TOKEN = 'mock-token'
+
+const mockAuth: Auth = {
+  initialised: true,
+  authenticated: true,
+  user: {
+    name: 'Mock User',
+    givenName: 'Mock',
+    familyName: 'User',
+    fedId: 'mock001',
+    email: 'mock@example.diamond.ac.uk',
+  },
+  login: () => {},
+  logout: () => {},
+  getToken: () => MOCK_TOKEN,
+}
+
+interface MockAuthProviderProps extends PropsWithChildren {
+  onTokenChange?: (token: string) => void
+}
+
+export const MockAuthProvider = ({ children, onTokenChange }: MockAuthProviderProps) => {
+  useEffect(() => {
+    onTokenChange?.(MOCK_TOKEN)
+  }, [onTokenChange])
+
+  return <AuthContext.Provider value={mockAuth}>{children}</AuthContext.Provider>
+}

--- a/apps/smartem/src/auth/config.ts
+++ b/apps/smartem/src/auth/config.ts
@@ -2,7 +2,6 @@ import type { KeycloakServerConfig } from 'keycloak-js'
 
 export interface RuntimeConfig {
   keycloak: KeycloakServerConfig
-  authEnabled: boolean
 }
 
 let runtimeConfig: RuntimeConfig | null = null
@@ -19,7 +18,5 @@ const getRuntimeConfig = (): RuntimeConfig => {
   }
   return runtimeConfig
 }
-
-export const isAuthEnabled = (): boolean => getRuntimeConfig().authEnabled
 
 export const getKeycloakConfig = (): KeycloakServerConfig => getRuntimeConfig().keycloak

--- a/apps/smartem/src/auth/index.ts
+++ b/apps/smartem/src/auth/index.ts
@@ -1,5 +1,6 @@
+export { useAuth } from './AuthContext'
 export { AuthGate } from './AuthGate'
-export { AuthProvider, useAuth } from './AuthProvider'
 export type { RuntimeConfig } from './config'
 export { setRuntimeConfig } from './config'
+export { KeycloakAuthProvider } from './KeycloakAuthProvider'
 export type { Auth, AuthUser } from './types'

--- a/apps/smartem/src/main.tsx
+++ b/apps/smartem/src/main.tsx
@@ -22,22 +22,18 @@ async function loadRuntimeConfig(): Promise<void> {
   setRuntimeConfig(config)
 }
 
-async function enableMocking(): Promise<void> {
-  if (import.meta.env.VITE_ENABLE_MOCKS !== 'true') {
-    return
-  }
-
+async function startMockWorker(): Promise<void> {
   const { worker } = await import('./mocks/browser')
-
   await worker.start({
     onUnhandledRequest: 'warn',
   })
 }
 
+const useMocks = import.meta.env.VITE_ENABLE_MOCKS === 'true'
+
 const rootElement = document.getElementById('root')
 if (rootElement && !rootElement.innerHTML) {
-  loadRuntimeConfig()
-    .then(() => enableMocking())
+  ;(useMocks ? startMockWorker() : loadRuntimeConfig())
     .then(() => {
       const root = createRoot(rootElement)
       root.render(


### PR DESCRIPTION
## Summary

- Drops `VITE_AUTH_ENABLED` env var and the `authEnabled` field from runtime `/config.json`. Auth is now structurally always-on at the UI layer; no off-toggle.
- Backend (smartem-decisions) already shipped always-on Keycloak validation (`2ec937d`); this brings the frontend posture in line.
- `dev:smartem:mock` keeps working via a new `MockAuthProvider` that emits a hardcoded user identity and a synthetic `Bearer mock-token`. Login/logout are no-ops; mock mode is for visual UI demo only.

## Design

`AuthGate` picks an auth provider at build time, keyed on `VITE_ENABLE_MOCKS`:

- `VITE_ENABLE_MOCKS=true` (`dev:smartem:mock`): `MockAuthProvider` starts in `initialised: true, authenticated: true`. `useEffect` emits `mock-token` via `onTokenChange` so the existing Axios interceptor in `@smartem/api` attaches `Authorization: Bearer mock-token` to every request. MSW handlers ignore the header.
- otherwise (`dev:smartem` and prod): `KeycloakAuthProvider`, behaviourally unchanged (just renamed from `AuthProvider`).

`AuthContext`, `defaultAuth`, and `useAuth` are hoisted into `apps/smartem/src/auth/AuthContext.ts` so both providers share one React context with the existing `Auth` shape.

`main.tsx` also short-circuits the `/config.json` fetch when mocks are on, so mock mode no longer has a `/config.json` boot dependency.

## Files

- New: `apps/smartem/src/auth/AuthContext.ts`, `apps/smartem/src/auth/MockAuthProvider.tsx`
- Renamed: `apps/smartem/src/auth/AuthProvider.tsx` → `KeycloakAuthProvider.tsx`
- Modified: `apps/smartem/src/auth/AuthGate.tsx`, `config.ts`, `index.ts`, `apps/smartem/src/main.tsx`, `apps/smartem/public/config.json`, `apps/smartem/.env.example`

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (only an unrelated Biome schema-version warning)
- [x] `npm run build:smartem` clean
- [x] `npm run format:check` clean
- [x] Browser verification of `dev:smartem:mock` via Playwright: app boots straight into the dashboard with no `SignInScreen`; Header shows "Mock User"; `GET /api/acquisitions` carries `Authorization: Bearer mock-token`; no `GET /config.json` request is made.
- [x] Browser verification of `dev:smartem` with no Keycloak reachable on `localhost:30090`: `/config.json` fetched, Keycloak iframe attempts time out, `SignInScreen` appears with "Failed to connect to Keycloak" error.
- [ ] Reviewer: verify against a running local Keycloak mock (`smartem-devtools/keycloak-mock`) — full sign-in redirect should land back on the dashboard with the Keycloak user's claims in the Header tooltip.

## Follow-up

A separate PR on smartem-devtools will:

- Drop `authEnabled` from any templated `config.json` ConfigMap in `k8s/`.
- Add a "Mock mode" subsection to `docs/architecture/keycloak-spa-authentication.{md,mdx}` so the doc reflects the MockAuthProvider path.