### PR TITLE
feat(dev): make Vite API proxy target configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A React-based web application for visualising and analysing electron microscopy 
 
 - Node.js 20 or later
 - npm or compatible package manager
-- SmartEM backend API running (default: http://localhost:8000)
+- SmartEM backend API running. The Vite dev server proxies `/api` to `http://localhost:8000` by default — set `VITE_API_PROXY_TARGET` (e.g. in `apps/smartem/.env.local`) to override, for example `http://localhost:30080` when running the dev k3s stack from [smartem-devtools](https://DiamondLightSource.github.io/smartem-devtools/operations/kubernetes).
 
 ## Quick Start
 

--- a/apps/legacy/vite.config.ts
+++ b/apps/legacy/vite.config.ts
@@ -1,18 +1,23 @@
 import tailwindcss from '@tailwindcss/vite'
 import { TanStackRouterVite } from '@tanstack/router-vite-plugin'
 import react from '@vitejs/plugin-react'
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import tsconfigPaths from 'vite-tsconfig-paths'
 
-export default defineConfig({
-  plugins: [react(), tailwindcss(), TanStackRouterVite(), tsconfigPaths()],
-  server: {
-    proxy: {
-      '/api': {
-        target: 'http://localhost:8000',
-        changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/api/, ''),
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+  const proxyTarget = env.VITE_API_PROXY_TARGET || 'http://localhost:8000'
+
+  return {
+    plugins: [react(), tailwindcss(), TanStackRouterVite(), tsconfigPaths()],
+    server: {
+      proxy: {
+        '/api': {
+          target: proxyTarget,
+          changeOrigin: true,
+          rewrite: (path) => path.replace(/^\/api/, ''),
+        },
       },
     },
-  },
+  }
 })

--- a/apps/smartem/.env.example
+++ b/apps/smartem/.env.example
@@ -7,3 +7,14 @@
 # because MSW is bundled conditionally. Mock mode also short-circuits the
 # /config.json fetch and uses MockAuthProvider in place of Keycloak.
 # VITE_ENABLE_MOCKS=true
+
+# Where the Vite dev server proxies `/api` requests. Defaults to
+# http://localhost:8000 to match a standalone backend (`uvicorn` directly,
+# or `kubectl port-forward svc/smartem-http-api-service 8000:80`).
+#
+# When running the dev k3s stack from smartem-devtools, the backend is also
+# exposed at the NodePort http://localhost:30080 - set the value below to
+# point at it without needing a port-forward. See
+# https://DiamondLightSource.github.io/smartem-devtools/operations/kubernetes
+# for the full list of dev stack URLs.
+# VITE_API_PROXY_TARGET=http://localhost:30080

--- a/apps/smartem/vite.config.ts
+++ b/apps/smartem/vite.config.ts
@@ -1,21 +1,26 @@
 import tailwindcss from '@tailwindcss/vite'
 import { TanStackRouterVite } from '@tanstack/router-vite-plugin'
 import react from '@vitejs/plugin-react'
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import tsconfigPaths from 'vite-tsconfig-paths'
 
-export default defineConfig({
-  plugins: [react(), tailwindcss(), TanStackRouterVite(), tsconfigPaths()],
-  resolve: {
-    dedupe: ['react', 'react-dom', 'react/jsx-runtime', '@mui/material'],
-  },
-  server: {
-    proxy: {
-      '/api': {
-        target: 'http://localhost:8000',
-        changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/api/, ''),
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+  const proxyTarget = env.VITE_API_PROXY_TARGET || 'http://localhost:8000'
+
+  return {
+    plugins: [react(), tailwindcss(), TanStackRouterVite(), tsconfigPaths()],
+    resolve: {
+      dedupe: ['react', 'react-dom', 'react/jsx-runtime', '@mui/material'],
+    },
+    server: {
+      proxy: {
+        '/api': {
+          target: proxyTarget,
+          changeOrigin: true,
+          rewrite: (path) => path.replace(/^\/api/, ''),
+        },
       },
     },
-  },
+  }
 })


### PR DESCRIPTION
## Summary

The Vite dev server proxies `/api` to `http://localhost:8000` by default — the conventional standalone backend port (`uvicorn` directly, or `kubectl port-forward svc/smartem-http-api-service 8000:80`). When the backend runs inside the local k3s dev stack from smartem-devtools, it's exposed on **NodePort 30080**, which until now meant either starting a port-forward to keep the default working or hand-editing `vite.config.ts`.

This PR reads `VITE_API_PROXY_TARGET` via `loadEnv` so the proxy destination can be set from `apps/smartem/.env.local` without touching the config or starting a port-forward. The default is unchanged, so anyone already on the port-forward workflow keeps working with no action.

- `apps/smartem/vite.config.ts` and `apps/legacy/vite.config.ts` both updated for parity until legacy is retired.
- `apps/smartem/.env.example` documents the var alongside `VITE_ENABLE_MOCKS`.
- Root README prerequisites note mentions the override and links to the smartem-devtools k8s ops page.

Companion docs update on the smartem-devtools side: DiamondLightSource/smartem-devtools#218 grows a "Pointing the SmartEM frontend dev server at this stack" subsection in `docs/operations/kubernetes.md`.

## Test plan

- [x] `npm run typecheck` clean across workspaces
- [x] `npx biome check` clean on the two `vite.config.ts` files
- [ ] Default path: `npm run dev:smartem` with no env var set proxies to `localhost:8000` (existing behaviour)
- [ ] Override: `VITE_API_PROXY_TARGET=http://localhost:30080 npm run dev:smartem` proxies to the k3s NodePort with no port-forward running