### PR TITLE
feat(smartem): wire grid-detail routes to real API via adapter layer

### DIFF
--- a/apps/smartem/src/data/api-adapters.ts
+++ b/apps/smartem/src/data/api-adapters.ts
@@ -1,0 +1,136 @@
+import type {
+  FoilHoleResponse,
+  FoilHoleStatus,
+  GridResponse,
+  GridSquareResponse,
+  GridSquareStatus,
+  GridStatus,
+  MicrographResponse,
+  MicrographStatus,
+  QualityPredictionModelResponse,
+} from '@smartem/api'
+import type {
+  MockFoilHole,
+  MockGrid,
+  MockGridSquare,
+  MockMicrograph,
+  MockPredictionModel,
+} from './mock-session-detail'
+
+// Bridge between the API-shaped responses (snake_case, nullable, richer schema) and the
+// UI components' MockGridSquare/MockFoilHole/MockMicrograph shapes (camelCase, denser).
+// Fields the API does not (yet) expose - quality predictions, latent coordinates, per-row
+// counts - are filled with safe defaults so the UI degrades gracefully until those
+// endpoints are wired.
+
+const gridSquareStatusMap: Record<GridSquareStatus, MockGridSquare['status']> = {
+  none: 'registered',
+  'all foil holes registered': 'registered',
+  'foil holes decision started': 'collected',
+  'foil holes decision completed': 'completed',
+}
+
+const foilHoleStatusMap: Record<FoilHoleStatus, MockFoilHole['status']> = {
+  none: 'none',
+  'micrographs detected': 'processed',
+}
+
+const micrographStatusMap: Record<MicrographStatus, MockMicrograph['processingStatus']> = {
+  none: 'pending',
+  'motion correction started': 'processing',
+  'motion correction completed': 'processing',
+  'ctf started': 'processing',
+  'ctf completed': 'processing',
+  'particle picking started': 'processing',
+  'particle picking completed': 'processing',
+  'particle selection started': 'processing',
+  'particle selection completed': 'completed',
+}
+
+const gridStatusMap: Record<GridStatus, MockGrid['status']> = {
+  none: 'queued',
+  'scan started': 'screening',
+  'scan completed': 'collecting',
+  'grid squares decision started': 'collecting',
+  'grid squares decision completed': 'completed',
+}
+
+export function gridResponseToMock(r: GridResponse): MockGrid {
+  return {
+    uuid: r.uuid,
+    name: r.name,
+    sessionId: r.acquisition_uuid ?? '',
+    status: r.status ? gridStatusMap[r.status] : 'queued',
+    scanStartTime: r.scan_start_time,
+    scanEndTime: r.scan_end_time,
+    squareCount: 0,
+    foilholeCount: 0,
+    micrographCount: 0,
+    avgQuality: null,
+  }
+}
+
+export function gridSquareResponseToMock(r: GridSquareResponse): MockGridSquare {
+  return {
+    uuid: r.uuid,
+    gridsquareId: r.gridsquare_id,
+    gridUuid: r.grid_uuid ?? '',
+    status: r.status ? gridSquareStatusMap[r.status] : 'registered',
+    centerX: r.center_x ?? 0,
+    centerY: r.center_y ?? 0,
+    sizeWidth: r.size_width ?? 200,
+    selected: r.selected ?? false,
+    defocus: r.defocus,
+    magnification: r.magnification,
+    quality: 0,
+    foilholeCount: 0,
+    latent: null,
+    hasImageData: r.image_path != null,
+  }
+}
+
+export function foilHoleResponseToMock(r: FoilHoleResponse): MockFoilHole {
+  return {
+    uuid: r.uuid,
+    foilholeId: r.foilhole_id,
+    gridsquareUuid: r.gridsquare_id ?? '',
+    status: r.status ? foilHoleStatusMap[r.status] : 'none',
+    xLocation: r.x_location ?? 0,
+    yLocation: r.y_location ?? 0,
+    diameter: r.diameter ?? 0,
+    quality: r.quality ?? 0,
+    isNearGridBar: r.is_near_grid_bar,
+    micrographCount: 0,
+    resolution: null,
+    astigmatism: null,
+    particleCount: null,
+    latent: null,
+  }
+}
+
+export function predictionModelResponseToMock(
+  r: QualityPredictionModelResponse
+): MockPredictionModel {
+  return {
+    id: r.name,
+    name: r.name,
+    version: 'unknown',
+    description: r.description,
+    type: 'grid-quality',
+  }
+}
+
+export function micrographResponseToMock(r: MicrographResponse): MockMicrograph {
+  return {
+    uuid: r.uuid,
+    micrographId: r.micrograph_id ?? '',
+    foilholeUuid: r.foilhole_uuid,
+    timestamp: r.acquisition_datetime ?? '',
+    processingStatus: micrographStatusMap[r.status],
+    resolution: r.ctf_max_resolution_estimate ?? 0,
+    defocus: r.defocus ?? 0,
+    astigmatism: 0,
+    motionTotal: r.total_motion ?? 0,
+    ctfFitResolution: r.ctf_max_resolution_estimate ?? 0,
+  }
+}

--- a/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.atlas.tsx
+++ b/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.atlas.tsx
@@ -1,27 +1,40 @@
 import { Box, IconButton, Tooltip, Typography } from '@mui/material'
+import {
+  useGetGridGridsGridUuidGet,
+  useGetGridGridsquaresGridsGridUuidGridsquaresGet,
+} from '@smartem/api'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { useMemo, useState } from 'react'
 import { AtlasMap } from '~/components/spatial/AtlasMap'
 import { LatentSpacePanel } from '~/components/spatial/LatentSpacePanel'
-import {
-  getGrid,
-  getGridPredictions,
-  getGridSquares,
-  getPredictionModels,
-} from '~/data/mock-session-detail'
+import { gridResponseToMock, gridSquareResponseToMock } from '~/data/api-adapters'
+import type { MockModelPredictions, MockPredictionModel } from '~/data/mock-session-detail'
 import { gray } from '~/theme'
 
 export const Route = createFileRoute('/acquisitions/$acquisitionId/grids/$gridId/atlas')({
   component: AtlasView,
 })
 
+// Prediction overlays and latent-space items rely on quality-prediction time series
+// endpoints that are not yet wired here; until then, pass empty arrays so the map
+// renders with selection/freeze/click intact but without prediction colouring.
+const NO_MODELS: MockPredictionModel[] = []
+const NO_PREDICTIONS: MockModelPredictions[] = []
+
 function AtlasView() {
   const { acquisitionId, gridId } = Route.useParams()
   const navigate = useNavigate()
-  const grid = getGrid(gridId)
-  const squares = getGridSquares(gridId)
-  const models = getPredictionModels()
-  const predictions = getGridPredictions(gridId)
+  const { data: gridResponse } = useGetGridGridsGridUuidGet(gridId)
+  const { data: squareResponses } = useGetGridGridsquaresGridsGridUuidGridsquaresGet(gridId)
+
+  const grid = useMemo(
+    () => (gridResponse ? gridResponseToMock(gridResponse) : null),
+    [gridResponse]
+  )
+  const squares = useMemo(
+    () => (squareResponses ?? []).map(gridSquareResponseToMock),
+    [squareResponses]
+  )
 
   const [showLatent, setShowLatent] = useState(false)
   const [selectedSquareId, setSelectedSquareId] = useState<string | null>(null)
@@ -67,8 +80,8 @@ function AtlasView() {
           squares={squares}
           gridName={grid?.name ?? gridId}
           onSquareClick={handleSquareNavigate}
-          predictions={predictions}
-          models={models}
+          predictions={NO_PREDICTIONS}
+          models={NO_MODELS}
           selectedSquareId={selectedSquareId}
           onSquareHover={(id) => {
             if (!frozen) setSelectedSquareId(id)

--- a/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.predictions.tsx
+++ b/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.predictions.tsx
@@ -1,15 +1,26 @@
+import { useGetPredictionModelsPredictionModelsGet } from '@smartem/api'
 import { createFileRoute } from '@tanstack/react-router'
+import { useMemo } from 'react'
 import { PredictionsView } from '~/components/predictions/PredictionsView'
-import { getGridPredictions, getPredictionModels } from '~/data/mock-session-detail'
+import { predictionModelResponseToMock } from '~/data/api-adapters'
+import type { MockModelPredictions } from '~/data/mock-session-detail'
 
 export const Route = createFileRoute('/acquisitions/$acquisitionId/grids/$gridId/predictions')({
   component: PredictionsRoute,
 })
 
-function PredictionsRoute() {
-  const { gridId } = Route.useParams()
-  const models = getPredictionModels()
-  const predictions = getGridPredictions(gridId)
+// Time-series prediction data per (model, grid) is fetched from the per-square /
+// per-foilhole quality-prediction endpoints; that wiring is a separate concern.
+// Until then, render the view with a real model list and an empty predictions array
+// so the picker is functional but charts are empty.
+const NO_PREDICTIONS: MockModelPredictions[] = []
 
-  return <PredictionsView models={models} predictions={predictions} />
+function PredictionsRoute() {
+  const { data: modelResponses } = useGetPredictionModelsPredictionModelsGet()
+  const models = useMemo(
+    () => (modelResponses ?? []).map(predictionModelResponseToMock),
+    [modelResponses]
+  )
+
+  return <PredictionsView models={models} predictions={NO_PREDICTIONS} />
 }

--- a/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.squares_.$squareId.holes_.$holeId.tsx
+++ b/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.squares_.$squareId.holes_.$holeId.tsx
@@ -1,6 +1,11 @@
+import {
+  useGetFoilholeFoilholesFoilholeUuidGet,
+  useGetFoilholeMicrographsFoilholesFoilholeUuidMicrographsGet,
+} from '@smartem/api'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { useMemo } from 'react'
 import { FoilholeDetail } from '~/components/foilhole/FoilholeDetail'
-import { getFoilHole, getMicrographs } from '~/data/mock-session-detail'
+import { foilHoleResponseToMock, micrographResponseToMock } from '~/data/api-adapters'
 
 export const Route = createFileRoute(
   '/acquisitions/$acquisitionId/grids/$gridId/squares_/$squareId/holes_/$holeId'
@@ -11,8 +16,22 @@ export const Route = createFileRoute(
 function FoilholeView() {
   const { acquisitionId, gridId, squareId, holeId } = Route.useParams()
   const navigate = useNavigate()
-  const foilhole = getFoilHole(holeId)
-  const micrographs = getMicrographs(holeId)
+  const { data: foilholeResponse } = useGetFoilholeFoilholesFoilholeUuidGet(holeId)
+  const { data: micrographResponses } =
+    useGetFoilholeMicrographsFoilholesFoilholeUuidMicrographsGet(holeId)
+
+  const micrographs = useMemo(
+    () => (micrographResponses ?? []).map(micrographResponseToMock),
+    [micrographResponses]
+  )
+  const foilhole = useMemo(() => {
+    if (!foilholeResponse) return null
+    const adapted = foilHoleResponseToMock(foilholeResponse)
+    // micrographCount is not in the API's FoilHoleResponse; derive it from the
+    // sibling micrographs query we already make so the metadata panel matches
+    // what the grid of cards renders.
+    return { ...adapted, micrographCount: micrographs.length }
+  }, [foilholeResponse, micrographs])
 
   if (!foilhole) return null
 

--- a/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.squares_.$squareId.index.tsx
+++ b/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.squares_.$squareId.index.tsx
@@ -1,6 +1,11 @@
+import {
+  useGetGridsquareFoilholesGridsquaresGridsquareUuidFoilholesGet,
+  useGetGridsquareGridsquaresGridsquareUuidGet,
+} from '@smartem/api'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { useMemo } from 'react'
 import { SquareMap } from '~/components/spatial/SquareMap'
-import { getFoilHoles, getGridSquare } from '~/data/mock-session-detail'
+import { foilHoleResponseToMock, gridSquareResponseToMock } from '~/data/api-adapters'
 
 export const Route = createFileRoute(
   '/acquisitions/$acquisitionId/grids/$gridId/squares_/$squareId/'
@@ -11,8 +16,18 @@ export const Route = createFileRoute(
 function SquareIndexView() {
   const { acquisitionId, gridId, squareId } = Route.useParams()
   const navigate = useNavigate()
-  const square = getGridSquare(squareId)
-  const foilholes = getFoilHoles(squareId)
+  const { data: squareResponse } = useGetGridsquareGridsquaresGridsquareUuidGet(squareId)
+  const { data: foilholeResponses } =
+    useGetGridsquareFoilholesGridsquaresGridsquareUuidFoilholesGet(squareId)
+
+  const square = useMemo(
+    () => (squareResponse ? gridSquareResponseToMock(squareResponse) : null),
+    [squareResponse]
+  )
+  const foilholes = useMemo(
+    () => (foilholeResponses ?? []).map(foilHoleResponseToMock),
+    [foilholeResponses]
+  )
 
   return (
     <SquareMap

--- a/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.workspace.tsx
+++ b/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.workspace.tsx
@@ -1,6 +1,11 @@
+import {
+  useGetGridGridsGridUuidGet,
+  useGetGridGridsquaresGridsGridUuidGridsquaresGet,
+} from '@smartem/api'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { useMemo } from 'react'
 import { WorkspaceView } from '~/components/workspace/WorkspaceView'
-import { getGrid, getGridSquares } from '~/data/mock-session-detail'
+import { gridResponseToMock, gridSquareResponseToMock } from '~/data/api-adapters'
 
 export const Route = createFileRoute('/acquisitions/$acquisitionId/grids/$gridId/workspace')({
   component: WorkspaceRoute,
@@ -9,8 +14,17 @@ export const Route = createFileRoute('/acquisitions/$acquisitionId/grids/$gridId
 function WorkspaceRoute() {
   const { acquisitionId, gridId } = Route.useParams()
   const navigate = useNavigate()
-  const grid = getGrid(gridId)
-  const squares = getGridSquares(gridId)
+  const { data: gridResponse } = useGetGridGridsGridUuidGet(gridId)
+  const { data: squareResponses } = useGetGridGridsquaresGridsGridUuidGridsquaresGet(gridId)
+
+  const grid = useMemo(
+    () => (gridResponse ? gridResponseToMock(gridResponse) : null),
+    [gridResponse]
+  )
+  const squares = useMemo(
+    () => (squareResponses ?? []).map(gridSquareResponseToMock),
+    [squareResponses]
+  )
 
   if (!grid) return null
 


### PR DESCRIPTION
## Summary

The five grid-detail routes (atlas, workspace, predictions, square-index, foilhole-detail) were rendering from mock data even when the SPA was built without mocks, because they imported `getGrid`/`getGridSquares`/`getFoilHoles`/etc. from `~/data/mock-session-detail`. With those mock IDs (`ses-001`...`ses-005`) baked into URLs, clicking from a real-API acquisition into a real grid UUID returned empty — the lookup helpers never matched anything real.

This PR rewires those routes to the generated `@smartem/api` React Query hooks via a small adapter layer that bridges API responses (snake_case, nullable, richer schema) to the existing `MockGrid`/`MockGridSquare`/`MockFoilHole`/`MockMicrograph` component prop shapes. Component types stay as-is — only the data source changes.

## What's wired

- `GET /grids/{uuid}` → grid header (name, status, scan times)
- `GET /grids/{uuid}/gridsquares` → atlas/workspace square grids
- `GET /gridsquares/{uuid}` + `GET /gridsquares/{uuid}/foilholes` → square detail + foilhole cards
- `GET /foilholes/{uuid}` + `GET /foilholes/{uuid}/micrographs` → foilhole detail + micrograph grid
- `GET /prediction-models` → predictions view model picker

## Adapter detail

`apps/smartem/src/data/api-adapters.ts` maps each API response shape into the `Mock*` shape the components were already typed against. Includes status-enum maps (e.g. `'foil holes decision completed'` → `'completed'`) so the existing status colouring works without rewriting components.

Patches `MockFoilHole.micrographCount` from the sibling micrographs query length so the metadata panel agrees with the rendered card grid.

## Known gaps left for follow-up

- Per-square / per-foilhole quality-prediction overlays on the Atlas view (passed empty arrays — `NO_PREDICTIONS`, `NO_MODELS`)
- Per-(model, grid) prediction time series for the Predictions view (model picker functional, charts empty)
- Latent-space coordinates on squares/foilholes (`sq.latent === null` path)
- `MockGridSquare.foilholeCount` / `MockFoilHole.resolution`/`astigmatism`/`particleCount` aggregation

## Test plan

- [x] `npm run typecheck` clean across workspaces
- [x] `npx biome check` clean on touched files
- [x] Live verification against `smartem_dump` DB via Playwright: all 5 routes render real data (atlas squares, workspace, predictions header, square detail with foilhole cards, foilhole detail with micrograph cards)
- [ ] Reviewer to sanity-check the status-enum maps in `api-adapters.ts` match the intended UI states