### PR TITLE
feat(smartem): wire dashboard to real API, leave instruments under construction

### DIFF
--- a/apps/smartem/src/components/dashboard/RealDashboard.tsx
+++ b/apps/smartem/src/components/dashboard/RealDashboard.tsx
@@ -1,0 +1,1114 @@
+import { Box, ButtonBase, Chip, CircularProgress, Tooltip, Typography } from '@mui/material'
+import { type AcquisitionResponse, useGetAcquisitionsAcquisitionsGet } from '@smartem/api'
+import { Link } from '@tanstack/react-router'
+import { useCallback, useMemo, useRef, useState } from 'react'
+import { gray, statusColors } from '~/theme'
+
+// ============================================================================
+// Acquisition status helpers
+// ============================================================================
+
+type AcqStatus = NonNullable<AcquisitionResponse['status']>
+
+const statusLabel: Record<AcqStatus, string> = {
+  planned: 'Planned',
+  started: 'Running',
+  paused: 'Paused',
+  completed: 'Completed',
+  abandoned: 'Abandoned',
+}
+
+const statusColor: Record<AcqStatus, string> = {
+  planned: statusColors.offline,
+  started: statusColors.running,
+  paused: statusColors.paused,
+  completed: statusColors.idle,
+  abandoned: statusColors.error,
+}
+
+function isActiveStatus(s: AcqStatus | null | undefined): boolean {
+  return s === 'started' || s === 'paused'
+}
+
+// ============================================================================
+// Formatting helpers
+// ============================================================================
+
+function parseTimeMs(iso: string | null | undefined): number | null {
+  if (!iso) return null
+  const t = new Date(iso).getTime()
+  return Number.isFinite(t) ? t : null
+}
+
+function formatDuration(startIso: string | null, endIso: string | null): string | null {
+  const start = parseTimeMs(startIso)
+  if (start == null) return null
+  const end = parseTimeMs(endIso) ?? Date.now()
+  const ms = Math.max(0, end - start)
+  const hours = Math.floor(ms / 3_600_000)
+  const mins = Math.floor((ms % 3_600_000) / 60_000)
+  if (hours === 0) return `${mins}m`
+  return `${hours}h ${mins}m`
+}
+
+function formatTimeShort(iso: string | null): string | null {
+  const t = parseTimeMs(iso)
+  if (t == null) return null
+  return new Date(t).toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit' })
+}
+
+// ============================================================================
+// Per-instrument-model colouring (stable hash to a small palette)
+// ============================================================================
+
+const INSTRUMENT_PALETTE = [
+  '#5878a3',
+  '#e59344',
+  '#6ba059',
+  '#d1605e',
+  '#a77c9f',
+  '#cbb766',
+  '#7a807c',
+  '#9caec1',
+] as const
+
+function hashString(s: string): number {
+  let h = 0
+  for (let i = 0; i < s.length; i++) {
+    h = (h * 31 + s.charCodeAt(i)) | 0
+  }
+  return Math.abs(h)
+}
+
+function instrumentColor(model: string): string {
+  return INSTRUMENT_PALETTE[hashString(model) % INSTRUMENT_PALETTE.length]
+}
+
+// ============================================================================
+// Shared widgets
+// ============================================================================
+
+function StatusDot({ color, pulse }: { color: string; pulse?: boolean }) {
+  return (
+    <Box
+      component="span"
+      sx={{
+        display: 'inline-block',
+        width: 8,
+        height: 8,
+        borderRadius: '50%',
+        backgroundColor: color,
+        flexShrink: 0,
+        ...(pulse && {
+          boxShadow: `0 0 0 0 ${color}60`,
+          animation: 'pulse 2s ease-in-out infinite',
+          '@keyframes pulse': {
+            '0%, 100%': { boxShadow: `0 0 0 0 ${color}60` },
+            '50%': { boxShadow: `0 0 0 4px ${color}00` },
+          },
+        }),
+      }}
+    />
+  )
+}
+
+function PanelHeader({ title, count, suffix }: { title: string; count?: number; suffix?: string }) {
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'baseline',
+        gap: 0.75,
+        px: 1.5,
+        py: 0.75,
+        borderBottom: '1px solid',
+        borderColor: 'divider',
+        flexShrink: 0,
+      }}
+    >
+      <Typography variant="h5">{title}</Typography>
+      {count != null && (
+        <Typography variant="caption" sx={{ fontWeight: 500 }}>
+          {count}
+        </Typography>
+      )}
+      {suffix && (
+        <Typography variant="caption" sx={{ fontSize: '0.6875rem' }}>
+          {suffix}
+        </Typography>
+      )}
+    </Box>
+  )
+}
+
+// ============================================================================
+// Resizable dividers
+// ============================================================================
+
+function useDrag(onDrag: (delta: number) => void) {
+  const dragging = useRef(false)
+  const lastPos = useRef(0)
+
+  return useCallback(
+    (axis: 'x' | 'y') => (e: React.MouseEvent) => {
+      e.preventDefault()
+      dragging.current = true
+      lastPos.current = axis === 'x' ? e.clientX : e.clientY
+
+      const onMove = (ev: MouseEvent) => {
+        if (!dragging.current) return
+        const pos = axis === 'x' ? ev.clientX : ev.clientY
+        const delta = pos - lastPos.current
+        lastPos.current = pos
+        onDrag(delta)
+      }
+
+      const onUp = () => {
+        dragging.current = false
+        document.removeEventListener('mousemove', onMove)
+        document.removeEventListener('mouseup', onUp)
+        document.body.style.cursor = ''
+        document.body.style.userSelect = ''
+      }
+
+      document.body.style.cursor = axis === 'x' ? 'col-resize' : 'row-resize'
+      document.body.style.userSelect = 'none'
+      document.addEventListener('mousemove', onMove)
+      document.addEventListener('mouseup', onUp)
+    },
+    [onDrag]
+  )
+}
+
+function DividerH({ onDrag }: { onDrag: (delta: number) => void }) {
+  const onMouseDown = useDrag(onDrag)
+  return (
+    <Box
+      onMouseDown={onMouseDown('y')}
+      sx={{
+        height: 8,
+        cursor: 'row-resize',
+        backgroundColor: 'transparent',
+        position: 'relative',
+        flexShrink: 0,
+        zIndex: 10,
+        '&:hover, &:active': { '& > div': { backgroundColor: 'primary.main', opacity: 1 } },
+      }}
+    >
+      <Box
+        sx={{
+          position: 'absolute',
+          left: '30%',
+          right: '30%',
+          top: '50%',
+          transform: 'translateY(-50%)',
+          height: 3,
+          borderRadius: 1,
+          backgroundColor: 'divider',
+          opacity: 0.5,
+          transition: 'all 0.15s',
+        }}
+      />
+    </Box>
+  )
+}
+
+function DividerV({ onDrag }: { onDrag: (delta: number) => void }) {
+  const onMouseDown = useDrag(onDrag)
+  return (
+    <Box
+      onMouseDown={onMouseDown('x')}
+      sx={{
+        width: 8,
+        cursor: 'col-resize',
+        backgroundColor: 'transparent',
+        position: 'relative',
+        flexShrink: 0,
+        zIndex: 10,
+        '&:hover, &:active': { '& > div': { backgroundColor: 'primary.main', opacity: 1 } },
+      }}
+    >
+      <Box
+        sx={{
+          position: 'absolute',
+          top: '30%',
+          bottom: '30%',
+          left: '50%',
+          transform: 'translateX(-50%)',
+          width: 3,
+          borderRadius: 1,
+          backgroundColor: 'divider',
+          opacity: 0.5,
+          transition: 'all 0.15s',
+        }}
+      />
+    </Box>
+  )
+}
+
+// ============================================================================
+// Timeline range toggle
+// ============================================================================
+
+type TimelineRange = 'today' | 'week' | 'month'
+
+const TIMELINE_RANGES: { key: TimelineRange; label: string }[] = [
+  { key: 'today', label: 'Today' },
+  { key: 'week', label: 'Week' },
+  { key: 'month', label: 'Month' },
+]
+
+function RangeToggle({
+  range,
+  onChange,
+}: {
+  range: TimelineRange
+  onChange: (r: TimelineRange) => void
+}) {
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        border: '1px solid',
+        borderColor: 'divider',
+        borderRadius: 1,
+        overflow: 'hidden',
+      }}
+    >
+      {TIMELINE_RANGES.map((r, idx) => (
+        <ButtonBase
+          key={r.key}
+          onClick={() => onChange(r.key)}
+          sx={{
+            px: 1,
+            height: 24,
+            fontSize: '0.6875rem',
+            fontWeight: range === r.key ? 600 : 400,
+            backgroundColor: range === r.key ? gray[50] : 'transparent',
+            color: range === r.key ? 'text.primary' : 'text.disabled',
+            '&:hover': { backgroundColor: gray[100] },
+            borderRight: idx < TIMELINE_RANGES.length - 1 ? '1px solid' : 'none',
+            borderColor: 'divider',
+          }}
+        >
+          {r.label}
+        </ButtonBase>
+      ))}
+    </Box>
+  )
+}
+
+// ============================================================================
+// Instruments panel (under construction)
+//
+// The microscope list will be wired once the backend exposes an /instruments
+// endpoint (see smartem-devtools#81). The selection/hover state machinery
+// below is intentionally kept intact so the same callbacks can later drive
+// real instrument items; only the display is stubbed.
+// ============================================================================
+
+function InstrumentsPanel({
+  selectedInstruments,
+  highlightedInstrument,
+}: {
+  selectedInstruments: Set<string>
+  highlightedInstrument: string | null
+  onToggleInstrument: (id: string) => void
+}) {
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden' }}>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 0.75,
+          px: 1.5,
+          py: 0.75,
+          borderBottom: '1px solid',
+          borderColor: 'divider',
+          flexShrink: 0,
+        }}
+      >
+        <Typography variant="h5">Instruments</Typography>
+        <Typography variant="caption" sx={{ fontSize: '0.6875rem', color: 'text.disabled' }}>
+          under construction
+        </Typography>
+        {selectedInstruments.size > 0 && (
+          <Typography
+            variant="caption"
+            sx={{ fontSize: '0.625rem', color: 'primary.main', fontWeight: 500 }}
+          >
+            ({selectedInstruments.size} selected)
+          </Typography>
+        )}
+      </Box>
+      <Box
+        sx={{
+          flex: 1,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: 0.5,
+          p: 3,
+          textAlign: 'center',
+        }}
+      >
+        <Typography variant="body2" sx={{ color: 'text.secondary', fontWeight: 500 }}>
+          Microscope list is awaiting a backend endpoint.
+        </Typography>
+        <Typography variant="caption" sx={{ color: 'text.disabled', maxWidth: 320 }}>
+          Selection here will filter the Sessions and Timeline panels once instruments are exposed
+          via the API (smartem-devtools#81). The reactive plumbing is in place — only the display is
+          stubbed.
+        </Typography>
+        {highlightedInstrument && (
+          <Typography variant="caption" sx={{ color: 'text.disabled', fontSize: '0.625rem' }}>
+            (highlight: {highlightedInstrument})
+          </Typography>
+        )}
+      </Box>
+    </Box>
+  )
+}
+
+// ============================================================================
+// Sessions / Acquisitions panel
+// ============================================================================
+
+function SessionRow({
+  acq,
+  expanded,
+  onToggle,
+  onHoverInstrument,
+}: {
+  acq: AcquisitionResponse
+  expanded: boolean
+  onToggle: (uuid: string) => void
+  onHoverInstrument: (id: string | null) => void
+}) {
+  const status: AcqStatus = acq.status ?? 'planned'
+  const color = statusColor[status]
+  const isRunning = status === 'started'
+  const instColor = acq.instrument_model ? instrumentColor(acq.instrument_model) : gray[600]
+
+  const duration = formatDuration(acq.start_time, acq.end_time)
+  const instrumentLabel = acq.instrument_model ?? acq.instrument_id ?? '—'
+
+  return (
+    <Box>
+      <Box
+        onClick={() => onToggle(acq.uuid)}
+        onMouseEnter={() => acq.instrument_model && onHoverInstrument(acq.instrument_model)}
+        onMouseLeave={() => onHoverInstrument(null)}
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1.5,
+          px: 1.5,
+          py: 0.75,
+          borderRadius: 1,
+          cursor: 'pointer',
+          backgroundColor: expanded ? gray[100] : 'transparent',
+          borderLeft: `2px solid ${expanded ? instColor : 'transparent'}`,
+          transition: 'all 0.1s ease',
+          '&:hover': { backgroundColor: gray[100] },
+        }}
+      >
+        <StatusDot color={color} pulse={isRunning} />
+        <Box sx={{ flex: 1, minWidth: 0 }}>
+          <Link
+            to="/acquisitions/$acquisitionId"
+            params={{ acquisitionId: acq.uuid }}
+            onClick={(e) => e.stopPropagation()}
+            style={{ textDecoration: 'none' }}
+          >
+            <Typography
+              variant="body2"
+              fontWeight={500}
+              noWrap
+              sx={{
+                color: 'text.primary',
+                '&:hover': { textDecoration: 'underline', color: 'primary.main' },
+              }}
+            >
+              {acq.name}
+            </Typography>
+          </Link>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <Typography variant="caption" sx={{ fontSize: '0.6875rem' }}>
+              {instrumentLabel}
+            </Typography>
+            {duration && (
+              <Typography variant="caption" sx={{ fontSize: '0.6875rem', color: 'text.disabled' }}>
+                {duration}
+              </Typography>
+            )}
+          </Box>
+        </Box>
+        <Chip
+          size="small"
+          label={statusLabel[status]}
+          sx={{
+            backgroundColor: `${color}14`,
+            color,
+            fontWeight: 500,
+            border: `1px solid ${color}40`,
+            height: 18,
+            fontSize: '0.625rem',
+            '& .MuiChip-label': { px: 0.75 },
+          }}
+        />
+      </Box>
+      {expanded && <SessionDetailCard acq={acq} />}
+    </Box>
+  )
+}
+
+function SessionDetailCard({ acq }: { acq: AcquisitionResponse }) {
+  const started = formatTimeShort(acq.start_time)
+  const ended = formatTimeShort(acq.end_time)
+
+  return (
+    <Box
+      sx={{
+        mx: 1.5,
+        mb: 1,
+        p: 1.25,
+        border: '1px solid',
+        borderColor: 'divider',
+        borderRadius: 1.5,
+        backgroundColor: '#fafbfc',
+      }}
+    >
+      <Box sx={{ display: 'flex', gap: 3, flexWrap: 'wrap' }}>
+        {started && <MetricItem label="Started" value={started} />}
+        {ended && <MetricItem label="Ended" value={ended} />}
+        {acq.instrument_model && <MetricItem label="Instrument" value={acq.instrument_model} />}
+        {acq.instrument_id && <MetricItem label="Instrument ID" value={acq.instrument_id} />}
+        {acq.storage_path && <MetricItem label="Storage" value={acq.storage_path} />}
+      </Box>
+    </Box>
+  )
+}
+
+function MetricItem({ label, value }: { label: string; value: string }) {
+  return (
+    <Box sx={{ minWidth: 0 }}>
+      <Typography
+        variant="caption"
+        sx={{ fontSize: '0.5625rem', color: 'text.disabled', display: 'block' }}
+      >
+        {label}
+      </Typography>
+      <Typography
+        variant="caption"
+        sx={{
+          fontWeight: 500,
+          fontVariantNumeric: 'tabular-nums',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          display: 'inline-block',
+          maxWidth: 240,
+        }}
+        noWrap
+      >
+        {value}
+      </Typography>
+    </Box>
+  )
+}
+
+function SessionsPanel({
+  acquisitions,
+  selectedInstruments,
+  expandedSession,
+  onToggleSession,
+  onHoverInstrument,
+}: {
+  acquisitions: AcquisitionResponse[]
+  selectedInstruments: Set<string>
+  expandedSession: string | null
+  onToggleSession: (uuid: string) => void
+  onHoverInstrument: (id: string | null) => void
+}) {
+  const hasFilter = selectedInstruments.size > 0
+
+  const matchesFilter = useCallback(
+    (acq: AcquisitionResponse) => {
+      if (!hasFilter) return true
+      if (acq.instrument_model && selectedInstruments.has(acq.instrument_model)) return true
+      if (acq.instrument_id && selectedInstruments.has(acq.instrument_id)) return true
+      return false
+    },
+    [hasFilter, selectedInstruments]
+  )
+
+  const sorted = useMemo(() => {
+    const list = acquisitions.filter(matchesFilter)
+    return [...list].sort((a, b) => {
+      const ta = parseTimeMs(a.start_time) ?? 0
+      const tb = parseTimeMs(b.start_time) ?? 0
+      return tb - ta
+    })
+  }, [acquisitions, matchesFilter])
+
+  const active = sorted.filter((a) => isActiveStatus(a.status))
+  const recent = sorted.filter((a) => !isActiveStatus(a.status))
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden' }}>
+      <PanelHeader
+        title="Acquisitions"
+        count={sorted.length}
+        suffix={hasFilter ? `filtered by ${selectedInstruments.size} instrument(s)` : undefined}
+      />
+      <Box
+        sx={{
+          flex: 1,
+          overflowY: 'auto',
+          px: 0.5,
+          pb: 1,
+          '&::-webkit-scrollbar': { width: 4 },
+          '&::-webkit-scrollbar-thumb': { backgroundColor: gray[300], borderRadius: 2 },
+        }}
+      >
+        {active.length > 0 && (
+          <>
+            <Typography variant="h6" sx={{ px: 1.5, pt: 1, pb: 0.5 }}>
+              Active
+            </Typography>
+            {active.map((acq) => (
+              <SessionRow
+                key={acq.uuid}
+                acq={acq}
+                expanded={expandedSession === acq.uuid}
+                onToggle={onToggleSession}
+                onHoverInstrument={onHoverInstrument}
+              />
+            ))}
+          </>
+        )}
+        {recent.length > 0 && (
+          <>
+            <Typography variant="h6" sx={{ px: 1.5, pt: 1.5, pb: 0.5 }}>
+              Recent
+            </Typography>
+            {recent.map((acq) => (
+              <SessionRow
+                key={acq.uuid}
+                acq={acq}
+                expanded={expandedSession === acq.uuid}
+                onToggle={onToggleSession}
+                onHoverInstrument={onHoverInstrument}
+              />
+            ))}
+          </>
+        )}
+        {sorted.length === 0 && (
+          <Box sx={{ p: 3, textAlign: 'center' }}>
+            <Typography variant="caption">No acquisitions</Typography>
+          </Box>
+        )}
+      </Box>
+    </Box>
+  )
+}
+
+// ============================================================================
+// Timeline (Gantt) panel
+//
+// Rows are unique `instrument_model` values present in the acquisitions list,
+// blocks are individual acquisitions positioned by their start/end timestamps.
+// Acquisitions with neither an instrument_model nor a start_time are omitted
+// (nothing to draw).
+// ============================================================================
+
+interface GanttConfig {
+  start: number
+  range: number
+  nowPct: number
+  ticks: { key: string; pct: number; label: string }[]
+  suffix: string
+}
+
+function buildGanttConfig(range: TimelineRange, nowMs: number): GanttConfig {
+  const HOUR = 3600_000
+  const DAY = 24 * HOUR
+
+  if (range === 'today') {
+    const start = nowMs - DAY
+    const span = DAY
+    const ticks = Array.from({ length: 9 }, (_, i) => {
+      const ms = start + i * 3 * HOUR
+      const d = new Date(ms)
+      return {
+        key: `h-${i}`,
+        pct: ((i * 3 * HOUR) / span) * 100,
+        label: d.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit' }),
+      }
+    })
+    return { start, range: span, nowPct: 100, ticks, suffix: '24 h' }
+  }
+
+  if (range === 'month') {
+    const start = nowMs - 30 * DAY
+    const span = 30 * DAY
+    const ticks: GanttConfig['ticks'] = []
+    for (let i = 0; i <= 30; i += 5) {
+      const ms = start + i * DAY
+      const d = new Date(ms)
+      ticks.push({
+        key: d.toISOString().slice(0, 10),
+        pct: ((i * DAY) / span) * 100,
+        label: d.toLocaleDateString('en-GB', { day: 'numeric', month: 'short' }),
+      })
+    }
+    return { start, range: span, nowPct: 100, ticks, suffix: '30 days' }
+  }
+
+  // week (default)
+  const start = nowMs - 7 * DAY
+  const span = 7 * DAY
+  const ticks = Array.from({ length: 8 }, (_, i) => {
+    const ms = start + i * DAY
+    const d = new Date(ms)
+    return {
+      key: d.toISOString().slice(0, 10),
+      pct: ((i * DAY) / span) * 100,
+      label: d.toLocaleDateString('en-GB', { weekday: 'short', day: 'numeric' }),
+    }
+  })
+  return { start, range: span, nowPct: 100, ticks, suffix: '7 days' }
+}
+
+interface GanttRow {
+  model: string
+  color: string
+  blocks: { acq: AcquisitionResponse; startMs: number; endMs: number }[]
+}
+
+function buildGanttRows(acquisitions: AcquisitionResponse[], nowMs: number): GanttRow[] {
+  const byModel = new Map<string, GanttRow>()
+  for (const acq of acquisitions) {
+    const model = acq.instrument_model
+    if (!model) continue
+    const startMs = parseTimeMs(acq.start_time)
+    if (startMs == null) continue
+    const endMs = parseTimeMs(acq.end_time) ?? nowMs
+
+    let row = byModel.get(model)
+    if (!row) {
+      row = { model, color: instrumentColor(model), blocks: [] }
+      byModel.set(model, row)
+    }
+    row.blocks.push({ acq, startMs, endMs })
+  }
+  return [...byModel.values()].sort((a, b) => a.model.localeCompare(b.model))
+}
+
+function GanttBlockEl({
+  block,
+  ganttStart,
+  ganttRange,
+  rowColor,
+  dimmed,
+}: {
+  block: GanttRow['blocks'][number]
+  ganttStart: number
+  ganttRange: number
+  rowColor: string
+  dimmed: boolean
+}) {
+  const leftPct = Math.max(0, ((block.startMs - ganttStart) / ganttRange) * 100)
+  const rightPct = Math.min(100, ((block.endMs - ganttStart) / ganttRange) * 100)
+  const widthPct = rightPct - leftPct
+  if (widthPct <= 0) return null
+
+  const status: AcqStatus = block.acq.status ?? 'planned'
+  const isActive = isActiveStatus(status)
+  const isAbandoned = status === 'abandoned'
+
+  return (
+    <Tooltip title={`${block.acq.name} (${statusLabel[status]})`} placement="top">
+      <Box
+        sx={{
+          position: 'absolute',
+          left: `${leftPct}%`,
+          width: `${widthPct}%`,
+          top: '15%',
+          height: '70%',
+          backgroundColor: rowColor,
+          opacity: dimmed ? 0.15 : isAbandoned ? 0.35 : 0.7,
+          borderRadius: 0.5,
+          cursor: 'pointer',
+          transition: 'opacity 0.15s ease',
+          '&:hover': { opacity: 1 },
+          ...(isActive && {
+            borderRight: `2px solid ${rowColor}`,
+            backgroundImage: `linear-gradient(90deg, ${rowColor} 0%, ${rowColor}cc 100%)`,
+          }),
+        }}
+      />
+    </Tooltip>
+  )
+}
+
+function GanttTimeline({
+  acquisitions,
+  activeInstruments,
+  range,
+  onRangeChange,
+}: {
+  acquisitions: AcquisitionResponse[]
+  activeInstruments: Set<string>
+  range: TimelineRange
+  onRangeChange: (r: TimelineRange) => void
+}) {
+  // nowMs is computed per render; for an idle dashboard this is fine since
+  // we don't memoise across multi-second updates. If/when we add live polling
+  // we may want to pin this on a state setter so blocks don't jitter.
+  const nowMs = Date.now()
+  const cfg = useMemo(() => buildGanttConfig(range, nowMs), [range, nowMs])
+  const rows = useMemo(() => buildGanttRows(acquisitions, nowMs), [acquisitions, nowMs])
+
+  const hasFilter = activeInstruments.size > 0
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden' }}>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 0.75,
+          px: 1.5,
+          py: 0.75,
+          borderBottom: '1px solid',
+          borderColor: 'divider',
+          flexShrink: 0,
+        }}
+      >
+        <Typography variant="h5">Timeline</Typography>
+        <Typography variant="caption" sx={{ fontSize: '0.6875rem' }}>
+          {cfg.suffix}
+        </Typography>
+        <Box sx={{ flex: 1 }} />
+        <RangeToggle range={range} onChange={onRangeChange} />
+      </Box>
+
+      <Box sx={{ flex: 1, display: 'flex', overflow: 'hidden' }}>
+        <Box
+          sx={{
+            width: 120,
+            flexShrink: 0,
+            display: 'flex',
+            flexDirection: 'column',
+            borderRight: '1px solid',
+            borderColor: 'divider',
+          }}
+        >
+          <Box sx={{ height: 20, flexShrink: 0 }} />
+          {rows.map((row) => {
+            const isActive = activeInstruments.has(row.model)
+            return (
+              <Box
+                key={row.model}
+                sx={{
+                  flex: 1,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'flex-end',
+                  pr: 1,
+                  backgroundColor: isActive ? `${row.color}08` : 'transparent',
+                }}
+              >
+                <Typography
+                  variant="caption"
+                  noWrap
+                  sx={{
+                    fontSize: '0.6875rem',
+                    fontWeight: isActive ? 600 : 400,
+                    color: isActive ? row.color : 'text.secondary',
+                  }}
+                >
+                  {row.model}
+                </Typography>
+              </Box>
+            )
+          })}
+          {rows.length === 0 && (
+            <Box sx={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+              <Typography variant="caption" sx={{ fontSize: '0.625rem', color: 'text.disabled' }}>
+                no data
+              </Typography>
+            </Box>
+          )}
+        </Box>
+
+        <Box sx={{ flex: 1, position: 'relative', overflow: 'hidden' }}>
+          <Box sx={{ height: 20, position: 'relative', flexShrink: 0 }}>
+            {cfg.ticks.map((tick) => (
+              <Typography
+                key={tick.key}
+                variant="caption"
+                sx={{
+                  position: 'absolute',
+                  left: `${tick.pct}%`,
+                  top: 2,
+                  transform: 'translateX(-50%)',
+                  fontSize: '0.5625rem',
+                  color: 'text.disabled',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {tick.label}
+              </Typography>
+            ))}
+          </Box>
+
+          <Box sx={{ position: 'absolute', top: 20, bottom: 0, left: 0, right: 0 }}>
+            {cfg.ticks.map((tick) => (
+              <Box
+                key={`line-${tick.key}`}
+                sx={{
+                  position: 'absolute',
+                  left: `${tick.pct}%`,
+                  top: 0,
+                  bottom: 0,
+                  width: '1px',
+                  backgroundColor: gray[200],
+                }}
+              />
+            ))}
+
+            <Box
+              sx={{
+                position: 'absolute',
+                left: `${cfg.nowPct}%`,
+                top: 0,
+                bottom: 0,
+                width: 1.5,
+                backgroundColor: statusColors.error,
+                zIndex: 2,
+                '&::before': {
+                  content: '""',
+                  position: 'absolute',
+                  top: -2,
+                  left: -3,
+                  width: 7,
+                  height: 7,
+                  borderRadius: '50%',
+                  backgroundColor: statusColors.error,
+                },
+              }}
+            />
+
+            {rows.map((row, rowIdx) => {
+              const isActive = activeInstruments.has(row.model)
+              const rowTop = `${(rowIdx / Math.max(rows.length, 1)) * 100}%`
+              const rowHeight = `${100 / Math.max(rows.length, 1)}%`
+
+              return (
+                <Box
+                  key={row.model}
+                  sx={{
+                    position: 'absolute',
+                    top: rowTop,
+                    height: rowHeight,
+                    left: 0,
+                    right: 0,
+                    borderBottom: `1px solid ${gray[50]}`,
+                    backgroundColor: isActive ? `${row.color}04` : 'transparent',
+                  }}
+                >
+                  {row.blocks.map((block) => (
+                    <GanttBlockEl
+                      key={block.acq.uuid}
+                      block={block}
+                      ganttStart={cfg.start}
+                      ganttRange={cfg.range}
+                      rowColor={row.color}
+                      dimmed={hasFilter && !isActive}
+                    />
+                  ))}
+                </Box>
+              )
+            })}
+          </Box>
+        </Box>
+      </Box>
+    </Box>
+  )
+}
+
+// ============================================================================
+// Dashboard top-level
+// ============================================================================
+
+const HEADER_H = 56
+const MIN_COL = 0.25
+const MAX_COL = 0.75
+const MIN_TIMELINE = 120
+const MAX_TIMELINE_FRAC = 0.6
+
+export default function RealDashboard() {
+  const { data: acquisitions, isLoading, error } = useGetAcquisitionsAcquisitionsGet()
+
+  // Instrument selection state - kept intact for when /instruments is wired
+  // (see smartem-devtools#81). For now only Sessions/Timeline read from it,
+  // and only the Acquisitions side derives instrument identities (from
+  // instrument_model on each acquisition).
+  const [selectedInstruments, setSelectedInstruments] = useState<Set<string>>(new Set())
+  const [hoveredInstrument, setHoveredInstrument] = useState<string | null>(null)
+  const [expandedSession, setExpandedSession] = useState<string | null>(null)
+  const [timelineRange, setTimelineRange] = useState<TimelineRange>('week')
+
+  const [leftFrac, setLeftFrac] = useState(0.5)
+  const [timelineH, setTimelineH] = useState(260)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  const handleVDrag = useCallback((delta: number) => {
+    if (!containerRef.current) return
+    const totalW = containerRef.current.offsetWidth
+    setLeftFrac((prev) => Math.min(MAX_COL, Math.max(MIN_COL, prev + delta / totalW)))
+  }, [])
+
+  const handleHDrag = useCallback((delta: number) => {
+    if (!containerRef.current) return
+    const totalH = containerRef.current.offsetHeight
+    const maxPx = totalH * MAX_TIMELINE_FRAC
+    setTimelineH((prev) => Math.min(maxPx, Math.max(MIN_TIMELINE, prev - delta)))
+  }, [])
+
+  const toggleInstrument = useCallback((id: string) => {
+    setSelectedInstruments((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }, [])
+
+  const toggleSession = useCallback((uuid: string) => {
+    setExpandedSession((prev) => (prev === uuid ? null : uuid))
+  }, [])
+
+  // Expanding a session also "highlights" its instrument model
+  const expandedInstrumentModel = useMemo(() => {
+    if (!expandedSession || !acquisitions) return null
+    return acquisitions.find((a) => a.uuid === expandedSession)?.instrument_model ?? null
+  }, [expandedSession, acquisitions])
+
+  // Combined set used by the timeline to dim non-relevant rows
+  const activeInstruments = useMemo(() => {
+    const set = new Set(selectedInstruments)
+    if (hoveredInstrument) set.add(hoveredInstrument)
+    if (expandedInstrumentModel) set.add(expandedInstrumentModel)
+    return set
+  }, [selectedInstruments, hoveredInstrument, expandedInstrumentModel])
+
+  // The instruments panel's own highlight: hover relay from sessions, or
+  // the expanded session's instrument model. Same shape as MockDashboard's
+  // contract so the panel can be swapped to a real one without rewiring.
+  const instrumentsPanelHighlight = hoveredInstrument ?? expandedInstrumentModel
+
+  if (isLoading) {
+    return (
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          height: `calc(100vh - ${HEADER_H}px)`,
+        }}
+      >
+        <CircularProgress size={28} />
+      </Box>
+    )
+  }
+
+  if (error) {
+    return (
+      <Box sx={{ p: 4, textAlign: 'center' }}>
+        <Typography variant="body1" color="error">
+          Failed to load acquisitions
+        </Typography>
+      </Box>
+    )
+  }
+
+  const acquisitionList = acquisitions ?? []
+
+  return (
+    <Box
+      ref={containerRef}
+      sx={{
+        height: `calc(100vh - ${HEADER_H}px)`,
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden',
+        p: 0.5,
+        backgroundColor: gray[50],
+      }}
+    >
+      <Box sx={{ flex: 1, display: 'flex', overflow: 'hidden', minHeight: 0 }}>
+        <Box
+          sx={{
+            width: `${leftFrac * 100}%`,
+            overflow: 'hidden',
+            borderRadius: 1,
+            border: '1px solid',
+            borderColor: 'divider',
+            backgroundColor: 'background.paper',
+          }}
+        >
+          <InstrumentsPanel
+            selectedInstruments={selectedInstruments}
+            highlightedInstrument={instrumentsPanelHighlight}
+            onToggleInstrument={toggleInstrument}
+          />
+        </Box>
+        <DividerV onDrag={handleVDrag} />
+        <Box
+          sx={{
+            flex: 1,
+            overflow: 'hidden',
+            borderRadius: 1,
+            border: '1px solid',
+            borderColor: 'divider',
+            backgroundColor: 'background.paper',
+          }}
+        >
+          <SessionsPanel
+            acquisitions={acquisitionList}
+            selectedInstruments={selectedInstruments}
+            expandedSession={expandedSession}
+            onToggleSession={toggleSession}
+            onHoverInstrument={setHoveredInstrument}
+          />
+        </Box>
+      </Box>
+
+      <DividerH onDrag={handleHDrag} />
+
+      <Box
+        sx={{
+          height: timelineH,
+          flexShrink: 0,
+          overflow: 'hidden',
+          borderRadius: 1,
+          border: '1px solid',
+          borderColor: 'divider',
+          backgroundColor: 'background.paper',
+        }}
+      >
+        <GanttTimeline
+          acquisitions={acquisitionList}
+          activeInstruments={activeInstruments}
+          range={timelineRange}
+          onRangeChange={setTimelineRange}
+        />
+      </Box>
+    </Box>
+  )
+}

--- a/apps/smartem/src/components/dashboard/RealDashboard.tsx
+++ b/apps/smartem/src/components/dashboard/RealDashboard.tsx
@@ -1,7 +1,12 @@
 import { Box, ButtonBase, Chip, CircularProgress, Tooltip, Typography } from '@mui/material'
-import { type AcquisitionResponse, useGetAcquisitionsAcquisitionsGet } from '@smartem/api'
+import {
+  type AcquisitionResponse,
+  useGetAcquisitionGridsAcquisitionsAcquisitionUuidGridsGet,
+  useGetAcquisitionsAcquisitionsGet,
+} from '@smartem/api'
 import { Link } from '@tanstack/react-router'
 import { useCallback, useMemo, useRef, useState } from 'react'
+import { ErrorBoundary } from '~/components/ErrorBoundary'
 import { gray, statusColors } from '~/theme'
 
 // ============================================================================
@@ -28,6 +33,27 @@ const statusColor: Record<AcqStatus, string> = {
 
 function isActiveStatus(s: AcqStatus | null | undefined): boolean {
   return s === 'started' || s === 'paused'
+}
+
+// Activity heuristic. The backend currently sets every acquisition to
+// `started` and never updates the status to `completed`, so a strict
+// status-based partition lumps the entire history into Active. Treat an
+// acquisition as Active only if its status flag agrees AND it began
+// within the recency window. Everything else lands in Recent.
+const ACTIVE_RECENCY_MS = 24 * 60 * 60 * 1000
+
+function isActiveNow(acq: AcquisitionResponse, nowMs: number): boolean {
+  if (!isActiveStatus(acq.status)) return false
+  const startMs = parseTimeMs(acq.start_time)
+  if (startMs == null) return false
+  return nowMs - startMs <= ACTIVE_RECENCY_MS
+}
+
+// Best-available identity for grouping/colouring acquisitions by instrument.
+// `instrument_model` is the canonical field but is null on most records in
+// the current DB; fall back to `instrument_id` so the panels still partition.
+function instrumentKey(acq: AcquisitionResponse): string | null {
+  return acq.instrument_model ?? acq.instrument_id ?? null
 }
 
 // ============================================================================
@@ -390,16 +416,17 @@ function SessionRow({
   const status: AcqStatus = acq.status ?? 'planned'
   const color = statusColor[status]
   const isRunning = status === 'started'
-  const instColor = acq.instrument_model ? instrumentColor(acq.instrument_model) : gray[600]
+  const identity = instrumentKey(acq)
+  const instColor = identity ? instrumentColor(identity) : gray[600]
 
   const duration = formatDuration(acq.start_time, acq.end_time)
-  const instrumentLabel = acq.instrument_model ?? acq.instrument_id ?? '—'
+  const instrumentLabel = identity ?? '—'
 
   return (
     <Box>
       <Box
         onClick={() => onToggle(acq.uuid)}
-        onMouseEnter={() => acq.instrument_model && onHoverInstrument(acq.instrument_model)}
+        onMouseEnter={() => identity && onHoverInstrument(identity)}
         onMouseLeave={() => onHoverInstrument(null)}
         sx={{
           display: 'flex',
@@ -466,6 +493,18 @@ function SessionRow({
 }
 
 function SessionDetailCard({ acq }: { acq: AcquisitionResponse }) {
+  // Lazy-fetch grids only when the row is expanded - one extra request per
+  // expansion rather than N+1 for the whole list. The hook only fires when
+  // this component is mounted (i.e. `expanded` is true upstream).
+  const { data: grids } = useGetAcquisitionGridsAcquisitionsAcquisitionUuidGridsGet(acq.uuid)
+  const gridsTotal = grids?.length
+  const gridsCompleted = grids?.filter(
+    (g) =>
+      g.status === 'grid squares decision completed' ||
+      g.status === 'scan completed' ||
+      g.status === 'grid squares decision started'
+  ).length
+
   const started = formatTimeShort(acq.start_time)
   const ended = formatTimeShort(acq.end_time)
 
@@ -481,7 +520,10 @@ function SessionDetailCard({ acq }: { acq: AcquisitionResponse }) {
         backgroundColor: '#fafbfc',
       }}
     >
-      <Box sx={{ display: 'flex', gap: 3, flexWrap: 'wrap' }}>
+      <Box sx={{ display: 'flex', gap: 3, flexWrap: 'wrap', alignItems: 'flex-start' }}>
+        {gridsTotal != null && (
+          <MetricItem label="Grids" value={`${gridsCompleted ?? 0}/${gridsTotal}`} />
+        )}
         {started && <MetricItem label="Started" value={started} />}
         {ended && <MetricItem label="Ended" value={ended} />}
         {acq.instrument_model && <MetricItem label="Instrument" value={acq.instrument_model} />}
@@ -537,9 +579,8 @@ function SessionsPanel({
   const matchesFilter = useCallback(
     (acq: AcquisitionResponse) => {
       if (!hasFilter) return true
-      if (acq.instrument_model && selectedInstruments.has(acq.instrument_model)) return true
-      if (acq.instrument_id && selectedInstruments.has(acq.instrument_id)) return true
-      return false
+      const key = instrumentKey(acq)
+      return key != null && selectedInstruments.has(key)
     },
     [hasFilter, selectedInstruments]
   )
@@ -553,8 +594,9 @@ function SessionsPanel({
     })
   }, [acquisitions, matchesFilter])
 
-  const active = sorted.filter((a) => isActiveStatus(a.status))
-  const recent = sorted.filter((a) => !isActiveStatus(a.status))
+  const nowMs = Date.now()
+  const active = sorted.filter((a) => isActiveNow(a, nowMs))
+  const recent = sorted.filter((a) => !isActiveNow(a, nowMs))
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden' }}>
@@ -683,28 +725,34 @@ function buildGanttConfig(range: TimelineRange, nowMs: number): GanttConfig {
 }
 
 interface GanttRow {
-  model: string
+  key: string
   color: string
-  blocks: { acq: AcquisitionResponse; startMs: number; endMs: number }[]
+  blocks: { acq: AcquisitionResponse; startMs: number; endMs: number; openEnded: boolean }[]
 }
 
 function buildGanttRows(acquisitions: AcquisitionResponse[], nowMs: number): GanttRow[] {
-  const byModel = new Map<string, GanttRow>()
+  const byKey = new Map<string, GanttRow>()
   for (const acq of acquisitions) {
-    const model = acq.instrument_model
-    if (!model) continue
+    const key = instrumentKey(acq)
+    if (!key) continue
     const startMs = parseTimeMs(acq.start_time)
     if (startMs == null) continue
-    const endMs = parseTimeMs(acq.end_time) ?? nowMs
+    const realEnd = parseTimeMs(acq.end_time)
+    const openEnded = realEnd == null
+    // Open-ended blocks (no real end_time) are rendered as a fixed-width
+    // marker rather than stretching to "now", which would create one giant
+    // overlap blob across the whole window when many acquisitions in the
+    // same row never closed.
+    const endMs = realEnd ?? Math.min(nowMs, startMs + 30 * 60 * 1000)
 
-    let row = byModel.get(model)
+    let row = byKey.get(key)
     if (!row) {
-      row = { model, color: instrumentColor(model), blocks: [] }
-      byModel.set(model, row)
+      row = { key, color: instrumentColor(key), blocks: [] }
+      byKey.set(key, row)
     }
-    row.blocks.push({ acq, startMs, endMs })
+    row.blocks.push({ acq, startMs, endMs, openEnded })
   }
-  return [...byModel.values()].sort((a, b) => a.model.localeCompare(b.model))
+  return [...byKey.values()].sort((a, b) => a.key.localeCompare(b.key))
 }
 
 function GanttBlockEl({
@@ -722,15 +770,20 @@ function GanttBlockEl({
 }) {
   const leftPct = Math.max(0, ((block.startMs - ganttStart) / ganttRange) * 100)
   const rightPct = Math.min(100, ((block.endMs - ganttStart) / ganttRange) * 100)
-  const widthPct = rightPct - leftPct
-  if (widthPct <= 0) return null
+  // Don't drop blocks whose computed span is sub-pixel; clamp to a minimum
+  // visible width so single-tick markers (e.g. open-ended acquisitions) still
+  // show up on Week/Month ranges.
+  const widthPct = Math.max(0.4, rightPct - leftPct)
+  if (rightPct <= 0 || leftPct >= 100) return null
 
   const status: AcqStatus = block.acq.status ?? 'planned'
-  const isActive = isActiveStatus(status)
   const isAbandoned = status === 'abandoned'
 
   return (
-    <Tooltip title={`${block.acq.name} (${statusLabel[status]})`} placement="top">
+    <Tooltip
+      title={`${block.acq.name} (${statusLabel[status]})${block.openEnded ? ' - open-ended' : ''}`}
+      placement="top"
+    >
       <Box
         sx={{
           position: 'absolute',
@@ -744,9 +797,10 @@ function GanttBlockEl({
           cursor: 'pointer',
           transition: 'opacity 0.15s ease',
           '&:hover': { opacity: 1 },
-          ...(isActive && {
-            borderRight: `2px solid ${rowColor}`,
-            backgroundImage: `linear-gradient(90deg, ${rowColor} 0%, ${rowColor}cc 100%)`,
+          ...(block.openEnded && {
+            // Hatched-look gradient to signal "still open / unknown duration"
+            backgroundImage: `repeating-linear-gradient(45deg, ${rowColor} 0 3px, ${rowColor}80 3px 6px)`,
+            borderRight: `1.5px dashed ${rowColor}`,
           }),
         }}
       />
@@ -809,10 +863,10 @@ function GanttTimeline({
         >
           <Box sx={{ height: 20, flexShrink: 0 }} />
           {rows.map((row) => {
-            const isActive = activeInstruments.has(row.model)
+            const isActive = activeInstruments.has(row.key)
             return (
               <Box
-                key={row.model}
+                key={row.key}
                 sx={{
                   flex: 1,
                   display: 'flex',
@@ -831,7 +885,7 @@ function GanttTimeline({
                     color: isActive ? row.color : 'text.secondary',
                   }}
                 >
-                  {row.model}
+                  {row.key}
                 </Typography>
               </Box>
             )
@@ -904,13 +958,13 @@ function GanttTimeline({
             />
 
             {rows.map((row, rowIdx) => {
-              const isActive = activeInstruments.has(row.model)
+              const isActive = activeInstruments.has(row.key)
               const rowTop = `${(rowIdx / Math.max(rows.length, 1)) * 100}%`
               const rowHeight = `${100 / Math.max(rows.length, 1)}%`
 
               return (
                 <Box
-                  key={row.model}
+                  key={row.key}
                   sx={{
                     position: 'absolute',
                     top: rowTop,
@@ -993,24 +1047,25 @@ export default function RealDashboard() {
     setExpandedSession((prev) => (prev === uuid ? null : uuid))
   }, [])
 
-  // Expanding a session also "highlights" its instrument model
-  const expandedInstrumentModel = useMemo(() => {
+  // Expanding a session also "highlights" its instrument (using the same
+  // identity key the Timeline rows are grouped by, so the highlight maps).
+  const expandedInstrumentKey = useMemo(() => {
     if (!expandedSession || !acquisitions) return null
-    return acquisitions.find((a) => a.uuid === expandedSession)?.instrument_model ?? null
+    const acq = acquisitions.find((a) => a.uuid === expandedSession)
+    return acq ? instrumentKey(acq) : null
   }, [expandedSession, acquisitions])
 
   // Combined set used by the timeline to dim non-relevant rows
   const activeInstruments = useMemo(() => {
     const set = new Set(selectedInstruments)
     if (hoveredInstrument) set.add(hoveredInstrument)
-    if (expandedInstrumentModel) set.add(expandedInstrumentModel)
+    if (expandedInstrumentKey) set.add(expandedInstrumentKey)
     return set
-  }, [selectedInstruments, hoveredInstrument, expandedInstrumentModel])
+  }, [selectedInstruments, hoveredInstrument, expandedInstrumentKey])
 
   // The instruments panel's own highlight: hover relay from sessions, or
-  // the expanded session's instrument model. Same shape as MockDashboard's
-  // contract so the panel can be swapped to a real one without rewiring.
-  const instrumentsPanelHighlight = hoveredInstrument ?? expandedInstrumentModel
+  // the expanded session's instrument key.
+  const instrumentsPanelHighlight = hoveredInstrument ?? expandedInstrumentKey
 
   if (isLoading) {
     return (
@@ -1062,11 +1117,13 @@ export default function RealDashboard() {
             backgroundColor: 'background.paper',
           }}
         >
-          <InstrumentsPanel
-            selectedInstruments={selectedInstruments}
-            highlightedInstrument={instrumentsPanelHighlight}
-            onToggleInstrument={toggleInstrument}
-          />
+          <ErrorBoundary label="Instruments panel">
+            <InstrumentsPanel
+              selectedInstruments={selectedInstruments}
+              highlightedInstrument={instrumentsPanelHighlight}
+              onToggleInstrument={toggleInstrument}
+            />
+          </ErrorBoundary>
         </Box>
         <DividerV onDrag={handleVDrag} />
         <Box
@@ -1079,13 +1136,15 @@ export default function RealDashboard() {
             backgroundColor: 'background.paper',
           }}
         >
-          <SessionsPanel
-            acquisitions={acquisitionList}
-            selectedInstruments={selectedInstruments}
-            expandedSession={expandedSession}
-            onToggleSession={toggleSession}
-            onHoverInstrument={setHoveredInstrument}
-          />
+          <ErrorBoundary label="Acquisitions panel">
+            <SessionsPanel
+              acquisitions={acquisitionList}
+              selectedInstruments={selectedInstruments}
+              expandedSession={expandedSession}
+              onToggleSession={toggleSession}
+              onHoverInstrument={setHoveredInstrument}
+            />
+          </ErrorBoundary>
         </Box>
       </Box>
 
@@ -1102,12 +1161,14 @@ export default function RealDashboard() {
           backgroundColor: 'background.paper',
         }}
       >
-        <GanttTimeline
-          acquisitions={acquisitionList}
-          activeInstruments={activeInstruments}
-          range={timelineRange}
-          onRangeChange={setTimelineRange}
-        />
+        <ErrorBoundary label="Timeline panel">
+          <GanttTimeline
+            acquisitions={acquisitionList}
+            activeInstruments={activeInstruments}
+            range={timelineRange}
+            onRangeChange={setTimelineRange}
+          />
+        </ErrorBoundary>
       </Box>
     </Box>
   )

--- a/apps/smartem/src/components/dashboard/RealDashboard.tsx
+++ b/apps/smartem/src/components/dashboard/RealDashboard.tsx
@@ -35,20 +35,6 @@ function isActiveStatus(s: AcqStatus | null | undefined): boolean {
   return s === 'started' || s === 'paused'
 }
 
-// Activity heuristic. The backend currently sets every acquisition to
-// `started` and never updates the status to `completed`, so a strict
-// status-based partition lumps the entire history into Active. Treat an
-// acquisition as Active only if its status flag agrees AND it began
-// within the recency window. Everything else lands in Recent.
-const ACTIVE_RECENCY_MS = 24 * 60 * 60 * 1000
-
-function isActiveNow(acq: AcquisitionResponse, nowMs: number): boolean {
-  if (!isActiveStatus(acq.status)) return false
-  const startMs = parseTimeMs(acq.start_time)
-  if (startMs == null) return false
-  return nowMs - startMs <= ACTIVE_RECENCY_MS
-}
-
 // Best-available identity for grouping/colouring acquisitions by instrument.
 // `instrument_model` is the canonical field but is null on most records in
 // the current DB; fall back to `instrument_id` so the panels still partition.
@@ -77,10 +63,18 @@ function formatDuration(startIso: string | null, endIso: string | null): string 
   return `${hours}h ${mins}m`
 }
 
-function formatTimeShort(iso: string | null): string | null {
+function formatDateTime(iso: string | null): string | null {
   const t = parseTimeMs(iso)
   if (t == null) return null
-  return new Date(t).toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit' })
+  // Historic data and long-running sessions need a full date plus time;
+  // a bare HH:MM is ambiguous once you're looking at months-old records.
+  return new Date(t).toLocaleString('en-GB', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
 }
 
 // ============================================================================
@@ -505,8 +499,8 @@ function SessionDetailCard({ acq }: { acq: AcquisitionResponse }) {
       g.status === 'grid squares decision started'
   ).length
 
-  const started = formatTimeShort(acq.start_time)
-  const ended = formatTimeShort(acq.end_time)
+  const started = formatDateTime(acq.start_time)
+  const ended = formatDateTime(acq.end_time)
 
   return (
     <Box
@@ -594,9 +588,13 @@ function SessionsPanel({
     })
   }, [acquisitions, matchesFilter])
 
-  const nowMs = Date.now()
-  const active = sorted.filter((a) => isActiveNow(a, nowMs))
-  const recent = sorted.filter((a) => !isActiveNow(a, nowMs))
+  // Status-only partition. We can't infer "is this still actually running"
+  // from start_time + recency because there's no reliable acquisition-end
+  // signal from the agent/backend yet (tracked separately - see PR comment
+  // referencing the new bug issue). When that lands, completed acquisitions
+  // will flow into Recent naturally via the status flag.
+  const active = sorted.filter((a) => isActiveStatus(a.status))
+  const recent = sorted.filter((a) => !isActiveStatus(a.status))
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden' }}>

--- a/apps/smartem/src/components/shell/Header.tsx
+++ b/apps/smartem/src/components/shell/Header.tsx
@@ -16,6 +16,7 @@ import {
 import { Link, useNavigate, useRouterState } from '@tanstack/react-router'
 import { useMemo, useState } from 'react'
 import { useAuth } from '~/auth'
+import { ErrorBoundary } from '~/components/ErrorBoundary'
 import { type CommandGroup, CommandPalette } from '~/components/widgets/CommandPalette'
 import { gray } from '~/theme'
 
@@ -206,19 +207,35 @@ export function Header() {
 
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, ml: 2, flexShrink: 0 }}>
             <SettingsMenu />
-            <AuthControls />
+            {/* AuthControls reads `useAuth()`; isolating it means a broken
+                auth context state can't blank out the rest of the header. */}
+            <ErrorBoundary
+              label="Auth controls"
+              fallback={() => (
+                <Typography variant="caption" sx={{ color: 'text.disabled', fontSize: '0.625rem' }}>
+                  auth error
+                </Typography>
+              )}
+            >
+              <AuthControls />
+            </ErrorBoundary>
           </Box>
         </Toolbar>
       </AppBar>
 
-      <CommandPalette
-        groups={commandGroups}
-        isOpen={paletteOpen}
-        onClose={() => setPaletteOpen(false)}
-        shortcutKey="/"
-        requireMeta={false}
-        placeholder="Search or jump to..."
-      />
+      {/* CommandPalette is a portaled modal with search/filter logic and
+          dynamic group rendering - the most non-trivial piece in the header.
+          A broken palette shouldn't take the header down with it. */}
+      <ErrorBoundary label="Command palette" fallback={() => null}>
+        <CommandPalette
+          groups={commandGroups}
+          isOpen={paletteOpen}
+          onClose={() => setPaletteOpen(false)}
+          shortcutKey="/"
+          requireMeta={false}
+          placeholder="Search or jump to..."
+        />
+      </ErrorBoundary>
     </>
   )
 }

--- a/apps/smartem/src/routes/index.tsx
+++ b/apps/smartem/src/routes/index.tsx
@@ -1,34 +1,25 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { lazy, Suspense } from 'react'
-import { EmptyState } from '~/components/EmptyState'
 import { ErrorBoundary } from '~/components/ErrorBoundary'
 
 // Inline check (rather than import from ~/data/mock-mode) so Vite's parse-time
-// substitution of import.meta.env makes this a constant `false` in live builds.
-// Rollup then drops the lazy import + the entire MockDashboard chunk.
-const MockDashboard =
+// substitution makes this a constant `false` in live builds. Rollup then drops
+// the lazy import + the entire MockDashboard chunk.
+const Dashboard =
   import.meta.env.VITE_ENABLE_MOCKS === 'true'
     ? lazy(() => import('~/components/dashboard/MockDashboard'))
-    : null
+    : lazy(() => import('~/components/dashboard/RealDashboard'))
 
 export const Route = createFileRoute('/')({
-  component: Dashboard,
+  component: DashboardRoute,
 })
 
-function Dashboard() {
-  if (MockDashboard) {
-    return (
-      <ErrorBoundary label="Dashboard">
-        <Suspense fallback={null}>
-          <MockDashboard />
-        </Suspense>
-      </ErrorBoundary>
-    )
-  }
+function DashboardRoute() {
   return (
-    <EmptyState
-      title="Dashboard not yet wired to the live API"
-      detail="The acquisitions, instruments and timeline panels rendered in mock mode are stubs against unimplemented endpoints. Use the Acquisitions link in the header to browse real data."
-    />
+    <ErrorBoundary label="Dashboard">
+      <Suspense fallback={null}>
+        <Dashboard />
+      </Suspense>
+    </ErrorBoundary>
   )
 }


### PR DESCRIPTION
## Summary

The dashboard at `/` used to render fake instruments, sessions and timeline from `~/data/mock-dashboard` even in live-API mode. The previous PR replaced that with an EmptyState placeholder; this one brings it back as a wired view.

Three panels:

- **Acquisitions** — sorted descending by `start_time`, split into Active (`started`/`paused`) and Recent. Each row links into the acquisition detail page and expands an in-place detail card with start/end timestamps, instrument model/id, and storage path.
- **Timeline (Gantt)** — one row per unique `instrument_model` present in the acquisitions list; each acquisition is a coloured block positioned by its start/end timestamps. Block colour comes from a stable hash of the model name into a small palette, so the same model is always the same colour across the dashboard.
- **Instruments** — under construction. Awaiting a backend `/instruments` endpoint (see smartem-devtools#81). The selection/hover/expanded-instrument state machinery is intentionally kept intact so the same callbacks can later drive a real instrument list without rewiring the Sessions or Timeline consumers. Selection still filters Sessions and dims non-matching Timeline rows; both react against the `instrument_model` identity for now.

## Routing

`routes/index.tsx` lazy-loads `MockDashboard` in mock mode (`VITE_ENABLE_MOCKS=true`) and `RealDashboard` otherwise. Inline `import.meta.env` check at the route module's top level lets Vite constant-fold and Rollup ship only one chunk per build:

| Build | Chunks present |
|---|---|
| `vite build` (live) | `RealDashboard-*.js` only |
| `VITE_ENABLE_MOCKS=true vite build` (mock) | `MockDashboard-*.js`, `MockContextStrip-*.js` only |

## Test plan

- [x] `npm run typecheck` clean
- [x] `npx biome check` clean on touched files
- [x] Live and mock builds both succeed
- [x] Live bundle contains zero references to mock-data identifiers (`krios-1`, `Krios I`, `Talos Arctica`, `ses-001`, `ribosome-highres`, etc.)
- [x] Mock bundle still ships MockDashboard chunks; no RealDashboard chunk
- [x] Dev server: `npm run dev:smartem` against local k3s API renders real acquisitions and timeline
- [ ] Reviewer: click an acquisition card → detail panel expands; click name → routes to `/acquisitions/<uuid>`
- [ ] Reviewer: change Timeline range to Today/Week/Month → ticks recompute, blocks reposition
- [ ] Reviewer: in mock mode (`npm run dev:smartem:mock`) the existing MockDashboard still renders unchanged

## Follow-up (not in scope)

- Wire the Instruments panel once smartem-devtools#81 lands a backend `/instruments` endpoint.
- The Acquisitions row currently doesn't display a grids-completed/total count — fetching grids per acquisition for the dashboard would be N+1 round-trips. A summary endpoint or a denormalised count on `AcquisitionResponse` would unblock that.