### PR TITLE
feat(api): observe-only semantic backend version check

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ Full documentation: <https://DiamondLightSource.github.io/smartem-devtools>
 
 When adding new API endpoints or modifying existing ones:
 
-1. Update the backend OpenAPI specification
-2. Run `npm run api:update` to regenerate the client
+1. Change the backend API in smartem-decisions — it regenerates and publishes the canonical OpenAPI spec
+2. Run `npm run api:update` to refresh `packages/api/src/openapi.json` from the canonical backend spec and regenerate the `@smartem/api` client
 3. Update components to use the new hooks
 4. Run `npm run typecheck` to verify type safety
 

--- a/apps/smartem/src/main.tsx
+++ b/apps/smartem/src/main.tsx
@@ -1,3 +1,4 @@
+import { checkApiVersion } from '@smartem/api'
 import { createRouter, RouterProvider } from '@tanstack/react-router'
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
@@ -29,6 +30,29 @@ async function startMockWorker(): Promise<void> {
   })
 }
 
+// Observe-only backend compatibility check (ADR 0020). Fire-and-forget so it never
+// blocks first paint; logs to the console always, and surfaces a non-blocking banner
+// in development only. Never enforced - rolling deploys may momentarily differ.
+function reportApiVersion(): void {
+  void checkApiVersion().then((info) => {
+    if (info.compatible) {
+      console.info(
+        `[API version] client ${info.clientVersion} <-> server ${info.serverVersion ?? 'unknown'} (compatible)`
+      )
+      return
+    }
+    console.warn(`[API version] ${info.message}`)
+    if (import.meta.env.DEV) {
+      const banner = document.createElement('div')
+      banner.textContent = info.message
+      banner.style.cssText =
+        'position:fixed;bottom:0;left:0;right:0;z-index:99999;padding:6px 12px;font:12px system-ui;' +
+        'background:#fef3c7;color:#92400e;border-top:1px solid #f59e0b;text-align:center'
+      document.body.appendChild(banner)
+    }
+  })
+}
+
 const useMocks = import.meta.env.VITE_ENABLE_MOCKS === 'true'
 
 const rootElement = document.getElementById('root')
@@ -43,6 +67,10 @@ if (rootElement && !rootElement.innerHTML) {
           </AuthGate>
         </StrictMode>
       )
+      // Live mode only - mock mode has no real backend to query.
+      if (!useMocks) {
+        reportApiVersion()
+      }
     })
     .catch((err) => {
       console.error('App boot failed:', err)

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "main": "src/index.ts",
   "scripts": {
-    "api:fetch": "curl -s https://diamondlightsource.github.io/smartem-devtools/api/smartem/swagger.json -o src/openapi.json",
+    "api:fetch": "curl -fsSL https://raw.githubusercontent.com/DiamondLightSource/smartem-decisions/main/docs/api/openapi.json -o src/openapi.json",
     "api:fetch:local": "curl -s http://localhost:8000/openapi.json -o src/openapi.json",
     "api:generate": "orval --config orval.config.ts && node scripts/extract-api-version.js",
     "api:update": "npm run api:fetch && npm run api:generate"

--- a/packages/api/src/version-check.ts
+++ b/packages/api/src/version-check.ts
@@ -10,16 +10,27 @@ export interface VersionInfo {
 }
 
 /**
- * Fetches the server's API version from the /status endpoint
+ * Reduce a setuptools_scm version to the portion that matters for compatibility:
+ * the release (and pre-release) segment, with the volatile PEP 440 local segment
+ * (`+gsha…`) and the `.devN` suffix stripped. The backend version changes on every
+ * commit, so comparing full strings is meaningless; comparing release portions is
+ * the semantic signal. Example: `0.1.1rc48.dev3+gcd5206327` -> `0.1.1rc48`.
+ */
+function releasePortion(version: string): string {
+  return version.split('+')[0].replace(/\.dev\d+$/, '')
+}
+
+/**
+ * Fetches the live backend API version from the `/version` endpoint (ADR 0020).
  */
 async function fetchServerVersion(): Promise<string | null> {
   try {
-    const response = await fetch(`${apiUrl()}/openapi.json`)
+    const response = await fetch(`${apiUrl()}/version`)
     if (!response.ok) {
       return null
     }
-    const spec = await response.json()
-    return spec.info?.version || null
+    const body = (await response.json()) as { version?: string }
+    return body.version ?? null
   } catch (error) {
     console.warn('Failed to fetch server API version:', error)
     return null
@@ -27,21 +38,25 @@ async function fetchServerVersion(): Promise<string | null> {
 }
 
 /**
- * Checks if the client API version matches the server API version
- * Returns version information and compatibility status
+ * Compares the backend API version the client was generated against (`API_VERSION`)
+ * with the live backend version, semantically. This is an OBSERVATION, never an
+ * enforced gate (ADR 0020): rolling deploys where the two momentarily differ must
+ * not break the app.
  */
 export async function checkApiVersion(): Promise<VersionInfo> {
   const serverVersion = await fetchServerVersion()
 
-  const compatible = serverVersion ? serverVersion === API_VERSION : true
+  const compatible = serverVersion
+    ? releasePortion(serverVersion) === releasePortion(API_VERSION)
+    : true
 
   let message = ''
   if (!serverVersion) {
     message = 'Unable to determine server API version'
   } else if (compatible) {
-    message = 'Client and server API versions match'
+    message = 'Client and server API versions are compatible'
   } else {
-    message = `API version mismatch: client expects ${API_VERSION} but server is ${serverVersion}`
+    message = `API version drift: client built against ${API_VERSION}, server reports ${serverVersion}`
   }
 
   return {
@@ -54,7 +69,7 @@ export async function checkApiVersion(): Promise<VersionInfo> {
 }
 
 /**
- * Logs API version information to console
+ * Logs API version information to the console. Observe-only.
  */
 export async function logApiVersion(): Promise<void> {
   const versionInfo = await checkApiVersion()
@@ -69,7 +84,7 @@ export async function logApiVersion(): Promise<void> {
 
   if (!versionInfo.compatible) {
     console.warn(
-      '⚠️  API version mismatch detected. Consider regenerating the client with `npm run api:update`'
+      '⚠️  API version drift detected (advisory). Run `npm run api:update` to rebuild the client against the current backend.'
     )
   }
 }


### PR DESCRIPTION
## Summary

Implements the **frontend side** of ADR 0020 (DiamondLightSource/smartem-devtools#222): finishes the backend-compatibility check and points the client at the canonical spec source.

- **Boot-time check wired into `apps/smartem/src/main.tsx`** (live mode only) — queries the backend `/version` endpoint and compares it **semantically** (release portion, ignoring the `dev+sha` suffix) to the version the client was built against. Logs always; shows a **non-blocking dev banner** on drift. **Never enforced** — rolling deploys that momentarily differ don't break the app.
- **`version-check.ts` rewritten** — fetches `/version` (was `/openapi.json`), semantic compare (was exact-string, which false-alarmed on every commit). Same exported surface, so the legacy `ApiVersionCheck` still builds.
- **`api:fetch` repointed** — pulls the canonical spec from smartem-decisions (`docs/api/openapi.json`) instead of the stale devtools Pages copy. `npm run api:update` is now safe and canonical.

## Notes

- The committed `openapi.json` is unchanged here (still has the endpoints from #108). Once the backend PR merges and publishes, a routine `npm run api:update` refreshes it; until then the observe-only check simply notes the client is slightly behind — which is honest and non-blocking.

## Companion PRs (merge together)

- DiamondLightSource/smartem-decisions#292 — `/version` endpoint + canonical publisher.
- DiamondLightSource/smartem-devtools#222 — ADR 0020 + sync pipeline.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npx biome check` clean on touched files (+ lefthook)
- [x] `npm run build:smartem` succeeds

Closes #93.