### PR TITLE
feat(smartem): feature flags + real command-palette search

### DIFF
--- a/apps/smartem/public/config.json
+++ b/apps/smartem/public/config.json
@@ -3,5 +3,11 @@
     "url": "http://localhost:30090",
     "realm": "dls",
     "clientId": "SmartEM_User"
+  },
+  "features": {
+    "depositions": false,
+    "agentLogs": false,
+    "darkMode": false,
+    "density": false
   }
 }

--- a/apps/smartem/src/auth/config.ts
+++ b/apps/smartem/src/auth/config.ts
@@ -2,6 +2,9 @@ import type { KeycloakServerConfig } from 'keycloak-js'
 
 export interface RuntimeConfig {
   keycloak: KeycloakServerConfig
+  // Optional per-deployment feature toggles, overlaid on the compile-time defaults in
+  // config/feature-flags.ts. Absent in mock mode (no config.json is loaded).
+  features?: Record<string, boolean>
 }
 
 let runtimeConfig: RuntimeConfig | null = null
@@ -20,3 +23,8 @@ const getRuntimeConfig = (): RuntimeConfig => {
 }
 
 export const getKeycloakConfig = (): KeycloakServerConfig => getRuntimeConfig().keycloak
+
+// Non-throwing: feature flags are optional and config is absent in mock mode, so callers
+// fall back to compile-time defaults rather than erroring.
+export const getRuntimeFeatureOverrides = (): Record<string, boolean> | undefined =>
+  runtimeConfig?.features

--- a/apps/smartem/src/components/shell/Header.tsx
+++ b/apps/smartem/src/components/shell/Header.tsx
@@ -13,18 +13,34 @@ import {
   Tooltip,
   Typography,
 } from '@mui/material'
+import {
+  useGetAcquisitionsAcquisitionsGet,
+  useGetGridsGridsGet,
+  useGetPredictionModelsPredictionModelsGet,
+} from '@smartem/api'
 import { Link, useNavigate, useRouterState } from '@tanstack/react-router'
 import { useMemo, useState } from 'react'
 import { useAuth } from '~/auth'
 import { ErrorBoundary } from '~/components/ErrorBoundary'
 import { type CommandGroup, CommandPalette } from '~/components/widgets/CommandPalette'
+import { type FeatureName, getFeatureFlag } from '~/config/feature-flags'
 import { gray } from '~/theme'
 
-const navLinks = [
+const navLinks: { label: string; to: string; flag?: FeatureName }[] = [
   { label: 'Acquisitions', to: '/acquisitions' },
   { label: 'Models', to: '/models' },
-  { label: 'Depositions', to: '/depositions' },
-] as const
+  { label: 'Depositions', to: '/depositions', flag: 'depositions' },
+]
+
+const NAV_KEYWORDS: Record<string, string[]> = {
+  Acquisitions: ['sessions', 'list', 'all'],
+  Models: ['ml', 'predictions'],
+  Depositions: ['aria', 'submit'],
+}
+
+// Cap dynamic groups so an empty query doesn't render hundreds of rows; fuzzy search
+// still narrows the full set as the user types.
+const PALETTE_GROUP_LIMIT = 25
 
 function NavLink({ label, to }: { label: string; to: string }) {
   const router = useRouterState()
@@ -58,31 +74,94 @@ export function Header() {
   const navigate = useNavigate()
   const [paletteOpen, setPaletteOpen] = useState(false)
 
-  const commandGroups: CommandGroup[] = useMemo(
-    () => [
+  // Only links whose feature flag (if any) is enabled. Drives both the header nav and the
+  // palette's Navigation group, so a gated feature is hidden in both places at once.
+  const visibleNavLinks = useMemo(
+    () => navLinks.filter((link) => !link.flag || getFeatureFlag(link.flag)),
+    []
+  )
+
+  // Palette search targets - fetched lazily once the palette is first opened, then cached.
+  const { data: acquisitions } = useGetAcquisitionsAcquisitionsGet({
+    query: { enabled: paletteOpen },
+  })
+  const { data: grids } = useGetGridsGridsGet({ query: { enabled: paletteOpen } })
+  const { data: models } = useGetPredictionModelsPredictionModelsGet({
+    query: { enabled: paletteOpen },
+  })
+
+  const commandGroups: CommandGroup[] = useMemo(() => {
+    const groups: CommandGroup[] = [
       {
         id: 'nav',
         label: 'Navigation',
-        items: navLinks.map((link) => ({
+        items: visibleNavLinks.map((link) => ({
           id: `nav-${link.to}`,
           label: link.label,
           onSelect: () => navigate({ to: link.to as string }),
-          keywords:
-            link.label === 'Acquisitions'
-              ? ['sessions', 'list', 'all']
-              : link.label === 'Models'
-                ? ['ml', 'predictions']
-                : link.label === 'Depositions'
-                  ? ['aria', 'submit']
-                  : ['home', 'overview'],
+          keywords: NAV_KEYWORDS[link.label] ?? ['home', 'overview'],
         })),
       },
-      // Acquisitions-by-name jump targets used to be sourced from the mock
-      // sessions list. They need the real API search endpoint, which is not
-      // wired yet; the group is left out rather than rendered from mocks.
-    ],
-    [navigate]
-  )
+    ]
+
+    if (acquisitions?.length) {
+      groups.push({
+        id: 'acquisitions',
+        label: 'Acquisitions',
+        items: acquisitions.slice(0, PALETTE_GROUP_LIMIT).map((a) => ({
+          id: `acq-${a.uuid}`,
+          label: a.name || a.uuid,
+          description: [a.status, a.instrument_model].filter(Boolean).join(' · ') || undefined,
+          keywords: [a.status, a.instrument_model, a.uuid].filter((k): k is string => Boolean(k)),
+          onSelect: () =>
+            navigate({ to: '/acquisitions/$acquisitionId', params: { acquisitionId: a.uuid } }),
+        })),
+      })
+    }
+
+    if (grids?.length) {
+      groups.push({
+        id: 'grids',
+        label: 'Grids',
+        items: grids.slice(0, PALETTE_GROUP_LIMIT).flatMap((g) => {
+          // A grid is only navigable with its parent acquisition; capture the id so the
+          // narrowing survives into the onSelect closure.
+          const acquisitionId = g.acquisition_uuid
+          if (!acquisitionId) return []
+          return [
+            {
+              id: `grid-${g.uuid}`,
+              label: g.name || g.uuid,
+              keywords: [g.uuid],
+              onSelect: () =>
+                navigate({
+                  to: '/acquisitions/$acquisitionId/grids/$gridId',
+                  params: { acquisitionId, gridId: g.uuid },
+                }),
+            },
+          ]
+        }),
+      })
+    }
+
+    if (models?.length) {
+      groups.push({
+        id: 'models',
+        label: 'Models',
+        items: models.slice(0, PALETTE_GROUP_LIMIT).map((m) => ({
+          id: `model-${m.name}`,
+          label: m.name,
+          description: m.description || undefined,
+          keywords: ['model', 'prediction'],
+          // Jumps to the catalogue for now; switch to '/models/$modelName' once the model
+          // detail route lands (DiamondLightSource/smartem-frontend#110).
+          onSelect: () => navigate({ to: '/models' }),
+        })),
+      })
+    }
+
+    return groups
+  }, [navigate, visibleNavLinks, acquisitions, grids, models])
 
   return (
     <>
@@ -148,8 +227,8 @@ export function Header() {
           </Typography>
 
           <Box sx={{ display: 'flex', gap: 0.25, mr: 2, flexShrink: 0 }}>
-            {navLinks.map((link) => (
-              <NavLink key={link.to} {...link} />
+            {visibleNavLinks.map((link) => (
+              <NavLink key={link.to} label={link.label} to={link.to} />
             ))}
           </Box>
 

--- a/apps/smartem/src/config/feature-flags.ts
+++ b/apps/smartem/src/config/feature-flags.ts
@@ -1,0 +1,30 @@
+import { getRuntimeFeatureOverrides } from '~/auth/config'
+
+// Compile-time defaults for every known feature flag. A deployment's config.json may
+// override any of these via its `features` map. Incomplete/experimental features default
+// to false so they stay hidden until explicitly enabled.
+export const FEATURE_DEFAULTS = {
+  // ARIA deposition workflow (route + nav link not built yet)
+  depositions: false,
+  // Agent log viewer (future, SSE-backed)
+  agentLogs: false,
+  // Dark colour scheme (designed separately)
+  darkMode: false,
+  // Display-density control (compact/comfortable/spacious)
+  density: false,
+} as const
+
+export type FeatureName = keyof typeof FEATURE_DEFAULTS
+
+// Resolves a flag: runtime override (config.json) wins, else the compile-time default.
+// Plain function (no React state) - runtime config is applied once before render and is
+// static thereafter, so this is safe to call directly in render or anywhere else.
+export function getFeatureFlag(name: FeatureName): boolean {
+  return getRuntimeFeatureOverrides()?.[name] ?? FEATURE_DEFAULTS[name]
+}
+
+// Hook form for ergonomic use in components. Non-reactive by design (flags don't change
+// during a session); it simply returns the resolved value.
+export function useFeatureFlag(name: FeatureName): boolean {
+  return getFeatureFlag(name)
+}


### PR DESCRIPTION
## Summary

Two pieces of the shell bundle: a **runtime feature-flag mechanism** and **real command-palette search**. No backend changes.

### Feature flags
- `RuntimeConfig` gains an optional `features` map; `config/feature-flags.ts` holds compile-time defaults plus `getFeatureFlag()` / `useFeatureFlag()`. The read is non-throwing, so mock mode (where no `config.json` is loaded) falls back to defaults instead of erroring.
- Gates the not-yet-built **Depositions** nav link behind the `depositions` flag (default off) — it no longer renders a dead link in either the header or the palette.
- `public/config.json` documents the `features` shape.

### Command-palette search
- The omnibox palette now searches real **Acquisitions / Grids / Models**, sourced from the generated `@smartem/api` hooks (fetched lazily on first open, capped per group), each item deep-linking to its route. The Navigation group is flag-aware.
- Model items jump to `/models` for now; switch to `/models/$modelName` once #110 merges.

## Verification

Mock mode (MSW), headless browser, **zero console/page errors**:
- Depositions hidden; header shows `Acquisitions` + `Models` only.
- Palette opens with `Navigation / Acquisitions / Grids / Models` groups populated from real data (items show `name` + `status · instrument` descriptions).
- Fuzzy search narrows results (empty → 17 items, `mod` → 9, `Acqu` → 1).
- Selecting an acquisition navigates to `/acquisitions/<id>`.

Screenshots: `tmp/verify-palette-open.png`, `tmp/verify-palette-search.png`.

## Scope / follow-ups

- The remaining shell-bundle items — a working **density toggle** and moving the palette into `packages/ui` — are deferred. The density toggle itself is trivial, but making it actually reflow the UI is a broader MUI-theme/component retrofit, better as its own change.
- In mock mode `config.json` isn't loaded, so flags resolve to defaults; live deployments read overrides from `config.json`'s `features` map.
