### PR TITLE
feat(smartem): legacy-parity batch 1 — square overlay & predictions, weight evolution, expandable foilholes

### DIFF
--- a/apps/smartem/src/components/shell/Header.tsx
+++ b/apps/smartem/src/components/shell/Header.tsx
@@ -153,9 +153,7 @@ export function Header() {
           label: m.name,
           description: m.description || undefined,
           keywords: ['model', 'prediction'],
-          // Jumps to the catalogue for now; switch to '/models/$modelName' once the model
-          // detail route lands (DiamondLightSource/smartem-frontend#110).
-          onSelect: () => navigate({ to: '/models' }),
+          onSelect: () => navigate({ to: '/models/$modelName', params: { modelName: m.name } }),
         })),
       })
     }

--- a/apps/smartem/src/components/spatial/SquareMap.tsx
+++ b/apps/smartem/src/components/spatial/SquareMap.tsx
@@ -10,9 +10,9 @@ import {
   valueToHeatmapColor,
 } from '~/utils/heatmap'
 
-type MetricKey = 'quality' | 'resolution' | 'astigmatism' | 'particleCount'
+type BaseMetric = 'quality' | 'resolution' | 'astigmatism' | 'particleCount'
 
-const METRIC_OPTIONS: Record<MetricKey, HeatmapOptions> = {
+const METRIC_OPTIONS: Record<BaseMetric, HeatmapOptions> = {
   quality: { label: 'Quality', type: 'linear', binCount: 5 },
   resolution: { label: 'Resolution (A)', max: 5, type: 'log', binCount: 5 },
   astigmatism: { label: 'Astigmatism (nm)', max: 50, type: 'log', binCount: 5 },
@@ -25,63 +25,103 @@ const METRIC_OPTIONS: Record<MetricKey, HeatmapOptions> = {
   },
 }
 
+const BASE_METRICS = Object.keys(METRIC_OPTIONS) as BaseMetric[]
+
+const metricButtonSx = (active: boolean) => ({
+  px: 0.75,
+  py: 0.25,
+  borderRadius: 0.5,
+  fontSize: '0.5625rem',
+  fontWeight: active ? 600 : 400,
+  color: active ? 'text.primary' : 'text.disabled',
+  backgroundColor: active ? gray[50] : 'transparent',
+  '&:hover': { backgroundColor: gray[100] },
+})
+
+// A prediction overlay layer: a model (or the cross-model "overall") whose predicted
+// per-foilhole quality colours the map. Selected via the same control as base metrics and
+// addressed internally as `pred:<id>`.
+export interface PredictionLayer {
+  id: string
+  label: string
+}
+
 interface SquareMapProps {
   foilholes: MockFoilHole[]
   squareLabel: string
   onFoilholeClick?: (uuid: string) => void
+  predictionLayers?: PredictionLayer[]
+  // layer id -> (foilhole uuid -> predicted value, 0..1)
+  predictionValues?: Record<string, Map<string, number>>
 }
 
-export function SquareMap({ foilholes, squareLabel, onFoilholeClick }: SquareMapProps) {
+export function SquareMap({
+  foilholes,
+  squareLabel,
+  onFoilholeClick,
+  predictionLayers = [],
+  predictionValues = {},
+}: SquareMapProps) {
   const [hoveredId, setHoveredId] = useState<string | null>(null)
   const [selectedId, setSelectedId] = useState<string | null>(null)
   const [selectionFrozen, setSelectionFrozen] = useState(false)
   const [tooltipPos, setTooltipPos] = useState({ x: 0, y: 0 })
-  const [metric, setMetric] = useState<MetricKey>('quality')
+  const [metric, setMetric] = useState<string>('quality')
   const [hideNull, setHideNull] = useState(false)
 
-  const useHeatmap = metric !== 'quality'
+  const predLayerId = metric.startsWith('pred:') ? metric.slice(5) : null
+  const isPred = predLayerId !== null
+  const baseMetric = isPred ? null : (metric as BaseMetric)
+  // Prediction layers are 0..1 scores coloured like quality; only the non-quality base
+  // metrics use the binned heatmap scale.
+  const useHeatmap = !isPred && metric !== 'quality'
 
   const metricValues = useMemo(() => {
-    if (!useHeatmap) return null
+    if (!useHeatmap || !baseMetric) return null
     return foilholes.map((fh) => {
-      if (metric === 'resolution') return fh.resolution
-      if (metric === 'astigmatism') return fh.astigmatism
-      if (metric === 'particleCount') return fh.particleCount
+      if (baseMetric === 'resolution') return fh.resolution
+      if (baseMetric === 'astigmatism') return fh.astigmatism
+      if (baseMetric === 'particleCount') return fh.particleCount
       return null
     })
-  }, [foilholes, metric, useHeatmap])
+  }, [foilholes, baseMetric, useHeatmap])
 
   const heatmapBins = useMemo(() => {
-    if (!metricValues) return [] as HeatmapBin[]
-    return computeHeatmapBins(metricValues, METRIC_OPTIONS[metric])
-  }, [metricValues, metric])
+    if (!metricValues || !baseMetric) return [] as HeatmapBin[]
+    return computeHeatmapBins(metricValues, METRIC_OPTIONS[baseMetric])
+  }, [metricValues, baseMetric])
 
   const getMetricValue = useCallback(
     (fh: MockFoilHole): number | null => {
+      if (isPred && predLayerId) return predictionValues[predLayerId]?.get(fh.uuid) ?? null
       if (metric === 'quality') return fh.quality
       if (metric === 'resolution') return fh.resolution
       if (metric === 'astigmatism') return fh.astigmatism
       if (metric === 'particleCount') return fh.particleCount
       return null
     },
-    [metric]
+    [isPred, predLayerId, predictionValues, metric]
   )
 
   const getFill = useCallback(
     (fh: MockFoilHole): string => {
+      if (isPred) {
+        const val = getMetricValue(fh)
+        return val != null ? qualityColor(val) : gray[600]
+      }
       if (!useHeatmap) return qualityColor(fh.quality)
       const val = getMetricValue(fh)
       return valueToHeatmapColor(val, heatmapBins) ?? gray[600]
     },
-    [useHeatmap, getMetricValue, heatmapBins]
+    [isPred, useHeatmap, getMetricValue, heatmapBins]
   )
 
   const isNullMetric = useCallback(
     (fh: MockFoilHole): boolean => {
-      if (!useHeatmap) return false
+      if (!useHeatmap && !isPred) return false
       return getMetricValue(fh) === null
     },
-    [useHeatmap, getMetricValue]
+    [useHeatmap, isPred, getMetricValue]
   )
 
   const handleClick = useCallback(
@@ -111,6 +151,7 @@ export function SquareMap({ foilholes, squareLabel, onFoilholeClick }: SquareMap
 
   const hoveredHole = hoveredId ? foilholes.find((h) => h.uuid === hoveredId) : null
   const selectedHole = selectedId ? foilholes.find((h) => h.uuid === selectedId) : null
+  const hoveredValue = hoveredHole ? getMetricValue(hoveredHole) : null
 
   const avgQuality =
     foilholes.length > 0 ? foilholes.reduce((sum, h) => sum + h.quality, 0) / foilholes.length : 0
@@ -225,9 +266,13 @@ export function SquareMap({ foilholes, squareLabel, onFoilholeClick }: SquareMap
             }}
           >
             {hoveredHole.foilholeId} —{' '}
-            {useHeatmap
-              ? `${getMetricValue(hoveredHole) ?? 'N/A'} ${METRIC_OPTIONS[metric].label}`
-              : `${Math.round(hoveredHole.quality * 100)}%`}
+            {isPred
+              ? hoveredValue != null
+                ? `${Math.round(hoveredValue * 100)}% predicted`
+                : 'no prediction'
+              : useHeatmap && baseMetric
+                ? `${hoveredValue ?? 'N/A'} ${METRIC_OPTIONS[baseMetric].label}`
+                : `${Math.round(hoveredHole.quality * 100)}%`}
             {hoveredHole.isNearGridBar && ' (near grid bar)'}
           </Box>
         )}
@@ -303,29 +348,37 @@ export function SquareMap({ foilholes, squareLabel, onFoilholeClick }: SquareMap
 
         <Box sx={{ flex: 1 }} />
 
-        {/* Metric selector */}
-        <Box sx={{ display: 'flex', gap: 0.25 }}>
-          {(Object.keys(METRIC_OPTIONS) as MetricKey[]).map((key) => (
+        {/* Metric / prediction-layer selector */}
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.25 }}>
+          {BASE_METRICS.map((key) => (
             <ButtonBase
               key={key}
               onClick={() => setMetric(key)}
-              sx={{
-                px: 0.75,
-                py: 0.25,
-                borderRadius: 0.5,
-                fontSize: '0.5625rem',
-                fontWeight: key === metric ? 600 : 400,
-                color: key === metric ? 'text.primary' : 'text.disabled',
-                backgroundColor: key === metric ? gray[50] : 'transparent',
-                '&:hover': { backgroundColor: gray[100] },
-              }}
+              sx={metricButtonSx(key === metric)}
             >
               {METRIC_OPTIONS[key].label.split(' ')[0]}
             </ButtonBase>
           ))}
+          {predictionLayers.length > 0 && (
+            <Box
+              sx={{ width: '1px', alignSelf: 'stretch', backgroundColor: 'divider', mx: 0.25 }}
+            />
+          )}
+          {predictionLayers.map((layer) => {
+            const key = `pred:${layer.id}`
+            return (
+              <ButtonBase
+                key={key}
+                onClick={() => setMetric(key)}
+                sx={metricButtonSx(key === metric)}
+              >
+                {layer.label}
+              </ButtonBase>
+            )
+          })}
         </Box>
 
-        {useHeatmap && (
+        {(useHeatmap || isPred) && (
           <FormControlLabel
             control={
               <Checkbox

--- a/apps/smartem/src/components/weights/WeightsTimeline.tsx
+++ b/apps/smartem/src/components/weights/WeightsTimeline.tsx
@@ -1,0 +1,221 @@
+import { Box, Typography } from '@mui/material'
+import type { QualityPredictionModelWeight } from '@smartem/api'
+import { useMemo } from 'react'
+import { gray, statusColors } from '~/theme'
+import { CLUSTER_PALETTE } from '~/utils/heatmap'
+
+interface Props {
+  weights: QualityPredictionModelWeight[]
+}
+
+interface MetricSeries {
+  metric: string
+  color: string
+  points: { t: number; weight: number }[]
+  mean: number
+  current: number
+  sdev: number
+  trendUp: boolean
+}
+
+function confidence(sdev: number): { label: string; color: string } {
+  if (sdev > 0.2) return { label: 'Highly uncertain', color: statusColors.error }
+  if (sdev > 0.1) return { label: 'Uncertain', color: statusColors.paused }
+  return { label: 'Confident', color: statusColors.running }
+}
+
+// Bespoke SVG weight-over-time chart (one line per metric) plus per-metric stats, ported in
+// spirit from the legacy MUI-x-charts component but kept dependency-free to match the app's
+// hand-rolled charts and not pre-empt the open charting-library decision.
+export function WeightsTimeline({ weights }: Props) {
+  const series = useMemo<MetricSeries[]>(() => {
+    const byMetric = new Map<string, { t: number; weight: number }[]>()
+    for (const w of weights) {
+      if (!w.metric_name) continue
+      const t = w.timestamp ? new Date(w.timestamp).getTime() : 0
+      const bucket = byMetric.get(w.metric_name)
+      const point = { t, weight: w.weight }
+      if (bucket) bucket.push(point)
+      else byMetric.set(w.metric_name, [point])
+    }
+    return Array.from(byMetric.entries())
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([metric, raw], i) => {
+        const points = [...raw].sort((a, b) => a.t - b.t)
+        const values = points.map((p) => p.weight)
+        const mean = values.reduce((s, v) => s + v, 0) / values.length
+        const tail = values.slice(-Math.max(1, Math.floor(values.length / 10)))
+        const tailAvg = tail.reduce((s, v) => s + v, 0) / tail.length
+        const sdev = Math.sqrt(
+          values.map((v) => (v - mean) ** 2).reduce((s, v) => s + v, 0) / values.length
+        )
+        return {
+          metric,
+          color: CLUSTER_PALETTE[i % CLUSTER_PALETTE.length],
+          points,
+          mean,
+          current: values[values.length - 1],
+          sdev,
+          trendUp: values[values.length - 1] >= tailAvg,
+        }
+      })
+  }, [weights])
+
+  if (series.length === 0) {
+    return (
+      <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+        No model weights recorded for this grid.
+      </Typography>
+    )
+  }
+
+  const W = 720
+  const H = 280
+  const pad = { top: 12, right: 12, bottom: 28, left: 36 }
+  const plotW = W - pad.left - pad.right
+  const plotH = H - pad.top - pad.bottom
+
+  const allT = series.flatMap((s) => s.points.map((p) => p.t))
+  const minT = Math.min(...allT)
+  const maxT = Math.max(...allT)
+  const maxW = Math.max(1, ...series.flatMap((s) => s.points.map((p) => p.weight)))
+  const tx = (t: number) => pad.left + (maxT === minT ? 0.5 : (t - minT) / (maxT - minT)) * plotW
+  const wy = (w: number) => pad.top + (1 - w / maxW) * plotH
+
+  return (
+    <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
+      <Box
+        sx={{
+          flex: '1 1 480px',
+          border: '1px solid',
+          borderColor: 'divider',
+          borderRadius: 1,
+          p: 2,
+        }}
+      >
+        <Typography variant="h6" sx={{ mb: 1 }}>
+          Weight over time
+        </Typography>
+        <svg
+          viewBox={`0 0 ${W} ${H}`}
+          style={{ width: '100%', height: 'auto' }}
+          role="img"
+          aria-label="Model weight history"
+        >
+          <line
+            x1={pad.left}
+            y1={pad.top}
+            x2={pad.left}
+            y2={pad.top + plotH}
+            stroke={gray[300]}
+            strokeWidth="1"
+          />
+          {[0, 0.25, 0.5, 0.75, 1].map((f) => {
+            const y = pad.top + (1 - f) * plotH
+            return (
+              <g key={f}>
+                <line
+                  x1={pad.left - 4}
+                  y1={y}
+                  x2={pad.left}
+                  y2={y}
+                  stroke={gray[300]}
+                  strokeWidth="1"
+                />
+                <text x={pad.left - 8} y={y + 3} textAnchor="end" fontSize="9" fill={gray[500]}>
+                  {(f * maxW).toFixed(1)}
+                </text>
+              </g>
+            )
+          })}
+          <line
+            x1={pad.left}
+            y1={pad.top + plotH}
+            x2={pad.left + plotW}
+            y2={pad.top + plotH}
+            stroke={gray[300]}
+            strokeWidth="1"
+          />
+          {series.map((s) => (
+            <g key={s.metric}>
+              <polyline
+                points={s.points.map((p) => `${tx(p.t)},${wy(p.weight)}`).join(' ')}
+                fill="none"
+                stroke={s.color}
+                strokeWidth="1.5"
+                opacity="0.9"
+              />
+              {s.points.map((p) => (
+                <circle
+                  key={`${s.metric}-${p.t}`}
+                  cx={tx(p.t)}
+                  cy={wy(p.weight)}
+                  r={2.5}
+                  fill={s.color}
+                />
+              ))}
+            </g>
+          ))}
+          <text
+            x={pad.left + plotW / 2}
+            y={H - 2}
+            textAnchor="middle"
+            fontSize="9"
+            fill={gray[500]}
+          >
+            time
+          </text>
+        </svg>
+      </Box>
+
+      <Box sx={{ flex: '1 1 280px', display: 'flex', flexDirection: 'column', gap: 0.75 }}>
+        {series.map((s) => {
+          const conf = confidence(s.sdev)
+          return (
+            <Box
+              key={s.metric}
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 1,
+                p: 1,
+                border: '1px solid',
+                borderColor: 'divider',
+                borderRadius: 1,
+              }}
+            >
+              <Box
+                sx={{
+                  width: 8,
+                  height: 8,
+                  borderRadius: '50%',
+                  backgroundColor: s.color,
+                  flexShrink: 0,
+                }}
+              />
+              <Typography variant="body2" sx={{ fontWeight: 600, minWidth: 96 }}>
+                {s.metric}
+              </Typography>
+              <Typography
+                variant="caption"
+                sx={{ color: 'text.secondary', fontVariantNumeric: 'tabular-nums' }}
+              >
+                {s.current.toFixed(2)} {s.trendUp ? '↑' : '↓'}
+              </Typography>
+              <Typography
+                variant="caption"
+                sx={{ color: 'text.disabled', fontVariantNumeric: 'tabular-nums' }}
+              >
+                μ {s.mean.toFixed(2)}
+              </Typography>
+              <Box sx={{ flex: 1 }} />
+              <Typography variant="caption" sx={{ color: conf.color, fontWeight: 500 }}>
+                {conf.label}
+              </Typography>
+            </Box>
+          )
+        })}
+      </Box>
+    </Box>
+  )
+}

--- a/apps/smartem/src/data/api-adapters.ts
+++ b/apps/smartem/src/data/api-adapters.ts
@@ -8,6 +8,7 @@ import type {
   LatentRepresentationResponse,
   MicrographResponse,
   MicrographStatus,
+  OverallQualityPrediction,
   QualityPredictionModelResponse,
   QualityPredictionResponse,
 } from '@smartem/api'
@@ -191,4 +192,24 @@ export function latentResponsesToCoordsByUuid(
     byUuid.set(r.gridsquare_uuid, { x: r.x, y: r.y, clusterIndex: r.index ?? 0 })
   }
   return byUuid
+}
+
+// Latest predicted value per foilhole for one (model, gridsquare), keyed by foilhole uuid -
+// drives the per-model prediction overlay on the square map.
+export function foilholePredictionMap(responses: QualityPredictionResponse[]): Map<string, number> {
+  const sorted = [...responses].sort((a, b) => a.timestamp.localeCompare(b.timestamp))
+  const byFoilhole = new Map<string, number>()
+  for (const r of sorted) {
+    if (r.foilhole_uuid) byFoilhole.set(r.foilhole_uuid, r.value)
+  }
+  return byFoilhole
+}
+
+// Cross-model "overall" predicted value per foilhole for a gridsquare.
+export function overallPredictionMap(responses: OverallQualityPrediction[]): Map<string, number> {
+  const byFoilhole = new Map<string, number>()
+  for (const r of responses) {
+    byFoilhole.set(r.foilhole_uuid, r.value)
+  }
+  return byFoilhole
 }

--- a/apps/smartem/src/routeTree.gen.ts
+++ b/apps/smartem/src/routeTree.gen.ts
@@ -25,6 +25,7 @@ import { Route as AcquisitionsAcquisitionIdGridsGridIdPredictionsRouteImport } f
 import { Route as AcquisitionsAcquisitionIdGridsGridIdAtlasRouteImport } from './routes/acquisitions.$acquisitionId.grids.$gridId.atlas'
 import { Route as AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdRouteImport } from './routes/acquisitions.$acquisitionId.grids.$gridId.squares_.$squareId'
 import { Route as AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdIndexRouteImport } from './routes/acquisitions.$acquisitionId.grids.$gridId.squares_.$squareId.index'
+import { Route as AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdPredictionsRouteImport } from './routes/acquisitions.$acquisitionId.grids.$gridId.squares_.$squareId.predictions'
 import { Route as AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdHolesHoleIdRouteImport } from './routes/acquisitions.$acquisitionId.grids.$gridId.squares_.$squareId.holes_.$holeId'
 
 const ModelsRoute = ModelsRouteImport.update({
@@ -118,6 +119,15 @@ const AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdIndexRoute =
     getParentRoute: () =>
       AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdRoute,
   } as any)
+const AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdPredictionsRoute =
+  AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdPredictionsRouteImport.update(
+    {
+      id: '/predictions',
+      path: '/predictions',
+      getParentRoute: () =>
+        AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdRoute,
+    } as any,
+  )
 const AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdHolesHoleIdRoute =
   AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdHolesHoleIdRouteImport.update(
     {
@@ -144,6 +154,7 @@ export interface FileRoutesByFullPath {
   '/acquisitions/$acquisitionId/grids/$gridId/workspace': typeof AcquisitionsAcquisitionIdGridsGridIdWorkspaceRoute
   '/acquisitions/$acquisitionId/grids/$gridId/': typeof AcquisitionsAcquisitionIdGridsGridIdIndexRoute
   '/acquisitions/$acquisitionId/grids/$gridId/squares/$squareId': typeof AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdRouteWithChildren
+  '/acquisitions/$acquisitionId/grids/$gridId/squares/$squareId/predictions': typeof AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdPredictionsRoute
   '/acquisitions/$acquisitionId/grids/$gridId/squares/$squareId/': typeof AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdIndexRoute
   '/acquisitions/$acquisitionId/grids/$gridId/squares/$squareId/holes/$holeId': typeof AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdHolesHoleIdRoute
 }
@@ -158,6 +169,7 @@ export interface FileRoutesByTo {
   '/acquisitions/$acquisitionId/grids/$gridId/squares': typeof AcquisitionsAcquisitionIdGridsGridIdSquaresRoute
   '/acquisitions/$acquisitionId/grids/$gridId/workspace': typeof AcquisitionsAcquisitionIdGridsGridIdWorkspaceRoute
   '/acquisitions/$acquisitionId/grids/$gridId': typeof AcquisitionsAcquisitionIdGridsGridIdIndexRoute
+  '/acquisitions/$acquisitionId/grids/$gridId/squares/$squareId/predictions': typeof AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdPredictionsRoute
   '/acquisitions/$acquisitionId/grids/$gridId/squares/$squareId': typeof AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdIndexRoute
   '/acquisitions/$acquisitionId/grids/$gridId/squares/$squareId/holes/$holeId': typeof AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdHolesHoleIdRoute
 }
@@ -178,6 +190,7 @@ export interface FileRoutesById {
   '/acquisitions/$acquisitionId/grids/$gridId/workspace': typeof AcquisitionsAcquisitionIdGridsGridIdWorkspaceRoute
   '/acquisitions/$acquisitionId/grids/$gridId/': typeof AcquisitionsAcquisitionIdGridsGridIdIndexRoute
   '/acquisitions/$acquisitionId/grids/$gridId/squares_/$squareId': typeof AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdRouteWithChildren
+  '/acquisitions/$acquisitionId/grids/$gridId/squares_/$squareId/predictions': typeof AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdPredictionsRoute
   '/acquisitions/$acquisitionId/grids/$gridId/squares_/$squareId/': typeof AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdIndexRoute
   '/acquisitions/$acquisitionId/grids/$gridId/squares_/$squareId/holes_/$holeId': typeof AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdHolesHoleIdRoute
 }
@@ -199,6 +212,7 @@ export interface FileRouteTypes {
     | '/acquisitions/$acquisitionId/grids/$gridId/workspace'
     | '/acquisitions/$acquisitionId/grids/$gridId/'
     | '/acquisitions/$acquisitionId/grids/$gridId/squares/$squareId'
+    | '/acquisitions/$acquisitionId/grids/$gridId/squares/$squareId/predictions'
     | '/acquisitions/$acquisitionId/grids/$gridId/squares/$squareId/'
     | '/acquisitions/$acquisitionId/grids/$gridId/squares/$squareId/holes/$holeId'
   fileRoutesByTo: FileRoutesByTo
@@ -213,6 +227,7 @@ export interface FileRouteTypes {
     | '/acquisitions/$acquisitionId/grids/$gridId/squares'
     | '/acquisitions/$acquisitionId/grids/$gridId/workspace'
     | '/acquisitions/$acquisitionId/grids/$gridId'
+    | '/acquisitions/$acquisitionId/grids/$gridId/squares/$squareId/predictions'
     | '/acquisitions/$acquisitionId/grids/$gridId/squares/$squareId'
     | '/acquisitions/$acquisitionId/grids/$gridId/squares/$squareId/holes/$holeId'
   id:
@@ -232,6 +247,7 @@ export interface FileRouteTypes {
     | '/acquisitions/$acquisitionId/grids/$gridId/workspace'
     | '/acquisitions/$acquisitionId/grids/$gridId/'
     | '/acquisitions/$acquisitionId/grids/$gridId/squares_/$squareId'
+    | '/acquisitions/$acquisitionId/grids/$gridId/squares_/$squareId/predictions'
     | '/acquisitions/$acquisitionId/grids/$gridId/squares_/$squareId/'
     | '/acquisitions/$acquisitionId/grids/$gridId/squares_/$squareId/holes_/$holeId'
   fileRoutesById: FileRoutesById
@@ -356,6 +372,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdIndexRouteImport
       parentRoute: typeof AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdRoute
     }
+    '/acquisitions/$acquisitionId/grids/$gridId/squares_/$squareId/predictions': {
+      id: '/acquisitions/$acquisitionId/grids/$gridId/squares_/$squareId/predictions'
+      path: '/predictions'
+      fullPath: '/acquisitions/$acquisitionId/grids/$gridId/squares/$squareId/predictions'
+      preLoaderRoute: typeof AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdPredictionsRouteImport
+      parentRoute: typeof AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdRoute
+    }
     '/acquisitions/$acquisitionId/grids/$gridId/squares_/$squareId/holes_/$holeId': {
       id: '/acquisitions/$acquisitionId/grids/$gridId/squares_/$squareId/holes_/$holeId'
       path: '/holes/$holeId'
@@ -367,12 +390,15 @@ declare module '@tanstack/react-router' {
 }
 
 interface AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdRouteChildren {
+  AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdPredictionsRoute: typeof AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdPredictionsRoute
   AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdIndexRoute: typeof AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdIndexRoute
   AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdHolesHoleIdRoute: typeof AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdHolesHoleIdRoute
 }
 
 const AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdRouteChildren: AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdRouteChildren =
   {
+    AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdPredictionsRoute:
+      AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdPredictionsRoute,
     AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdIndexRoute:
       AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdIndexRoute,
     AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdHolesHoleIdRoute:

--- a/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.squares.tsx
+++ b/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.squares.tsx
@@ -1,6 +1,7 @@
 import {
   Box,
   CircularProgress,
+  IconButton,
   Table,
   TableBody,
   TableCell,
@@ -11,10 +12,13 @@ import {
   Typography,
 } from '@mui/material'
 import type { GridSquareStatus } from '@smartem/api'
-import { useGetGridGridsquaresGridsGridUuidGridsquaresGet } from '@smartem/api'
+import {
+  useGetGridGridsquaresGridsGridUuidGridsquaresGet,
+  useGetGridsquareFoilholesGridsquaresGridsquareUuidFoilholesGet,
+} from '@smartem/api'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
-import { useMemo, useState } from 'react'
-import { statusColors } from '~/theme'
+import { Fragment, useMemo, useState } from 'react'
+import { gray, statusColors } from '~/theme'
 
 export const Route = createFileRoute('/acquisitions/$acquisitionId/grids/$gridId/squares')({
   component: SquaresTable,
@@ -34,6 +38,16 @@ function SquaresTable() {
 
   const [sortField, setSortField] = useState<SortField>('gridsquareId')
   const [sortDir, setSortDir] = useState<SortDir>('asc')
+  const [expanded, setExpanded] = useState<Set<string>>(new Set())
+
+  const toggleExpanded = (uuid: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev)
+      if (next.has(uuid)) next.delete(uuid)
+      else next.add(uuid)
+      return next
+    })
+  }
 
   const sorted = useMemo(() => {
     const arr = [...(squares ?? [])]
@@ -79,6 +93,7 @@ function SquaresTable() {
       <Table stickyHeader size="small">
         <TableHead>
           <TableRow>
+            <TableCell sx={{ width: 36 }} />
             <TableCell>
               <TableSortLabel
                 active={sortField === 'gridsquareId'}
@@ -111,52 +126,182 @@ function SquaresTable() {
           </TableRow>
         </TableHead>
         <TableBody>
-          {sorted.map((sq) => (
-            <TableRow
-              key={sq.uuid}
-              hover
-              sx={{ cursor: 'pointer' }}
-              onClick={() =>
-                navigate({
-                  to: '/acquisitions/$acquisitionId/grids/$gridId/squares/$squareId',
-                  params: { acquisitionId, gridId, squareId: sq.uuid },
-                })
-              }
-            >
-              <TableCell>
-                <Typography variant="body2" fontWeight={500}>
-                  {sq.gridsquare_id}
-                </Typography>
-              </TableCell>
-              <TableCell>
-                <StatusLabel status={sq.status} />
-              </TableCell>
-              <TableCell>
-                <Typography variant="body2" color={sq.selected ? 'text.primary' : 'text.disabled'}>
-                  {sq.selected ? 'Yes' : 'No'}
-                </Typography>
-              </TableCell>
-              <TableCell>
-                <Typography
-                  variant="body2"
-                  sx={{ fontVariantNumeric: 'tabular-nums', color: 'text.secondary' }}
+          {sorted.map((sq) => {
+            const isOpen = expanded.has(sq.uuid)
+            return (
+              <Fragment key={sq.uuid}>
+                <TableRow
+                  hover
+                  sx={{
+                    cursor: 'pointer',
+                    '& > td': { borderBottom: isOpen ? 'none' : undefined },
+                  }}
+                  onClick={() =>
+                    navigate({
+                      to: '/acquisitions/$acquisitionId/grids/$gridId/squares/$squareId',
+                      params: { acquisitionId, gridId, squareId: sq.uuid },
+                    })
+                  }
                 >
-                  {sq.defocus != null ? `${sq.defocus} um` : '--'}
+                  <TableCell sx={{ width: 36, pr: 0 }}>
+                    <IconButton
+                      size="small"
+                      aria-label={isOpen ? 'Collapse foilholes' : 'Expand foilholes'}
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        toggleExpanded(sq.uuid)
+                      }}
+                      sx={{ p: 0.25 }}
+                    >
+                      <Chevron open={isOpen} />
+                    </IconButton>
+                  </TableCell>
+                  <TableCell>
+                    <Typography variant="body2" fontWeight={500}>
+                      {sq.gridsquare_id}
+                    </Typography>
+                  </TableCell>
+                  <TableCell>
+                    <StatusLabel status={sq.status} />
+                  </TableCell>
+                  <TableCell>
+                    <Typography
+                      variant="body2"
+                      color={sq.selected ? 'text.primary' : 'text.disabled'}
+                    >
+                      {sq.selected ? 'Yes' : 'No'}
+                    </Typography>
+                  </TableCell>
+                  <TableCell>
+                    <Typography
+                      variant="body2"
+                      sx={{ fontVariantNumeric: 'tabular-nums', color: 'text.secondary' }}
+                    >
+                      {sq.defocus != null ? `${sq.defocus} um` : '--'}
+                    </Typography>
+                  </TableCell>
+                  <TableCell>
+                    <Typography
+                      variant="body2"
+                      sx={{ fontVariantNumeric: 'tabular-nums', color: 'text.secondary' }}
+                    >
+                      {sq.magnification != null ? `${(sq.magnification / 1000).toFixed(0)}k` : '--'}
+                    </Typography>
+                  </TableCell>
+                </TableRow>
+                {isOpen && (
+                  <TableRow>
+                    <TableCell colSpan={6} sx={{ py: 0, backgroundColor: gray[50] }}>
+                      <FoilholeSubTable squareUuid={sq.uuid} />
+                    </TableCell>
+                  </TableRow>
+                )}
+              </Fragment>
+            )
+          })}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  )
+}
+
+// Lazily loaded when a square row is expanded: its foilholes with a weighted aggregate
+// (mean predicted quality) and a per-foilhole table sortable by quality.
+function FoilholeSubTable({ squareUuid }: { squareUuid: string }) {
+  const { data: foilholes, isLoading } =
+    useGetGridsquareFoilholesGridsquaresGridsquareUuidFoilholesGet(squareUuid)
+  const [dir, setDir] = useState<SortDir>('desc')
+
+  const rows = useMemo(() => {
+    const arr = [...(foilholes ?? [])]
+    arr.sort((a, b) => {
+      const cmp = (a.quality ?? 0) - (b.quality ?? 0)
+      return dir === 'desc' ? -cmp : cmp
+    })
+    return arr
+  }, [foilholes, dir])
+
+  if (isLoading) {
+    return (
+      <Box sx={{ p: 1.5 }}>
+        <CircularProgress size={16} />
+      </Box>
+    )
+  }
+
+  if (rows.length === 0) {
+    return (
+      <Typography variant="caption" sx={{ color: 'text.disabled', p: 1.5, display: 'block' }}>
+        No foilholes recorded for this square.
+      </Typography>
+    )
+  }
+
+  const qualities = rows.map((r) => r.quality).filter((q): q is number => q != null)
+  const avg = qualities.length > 0 ? qualities.reduce((s, q) => s + q, 0) / qualities.length : null
+
+  return (
+    <Box sx={{ pl: 6, pr: 2, py: 1 }}>
+      <Typography variant="caption" sx={{ fontWeight: 600 }}>
+        {rows.length} foilholes
+        {avg != null ? ` · weighted quality ${Math.round(avg * 100)}%` : ''}
+      </Typography>
+      <Table size="small" sx={{ mt: 0.5, maxWidth: 460 }}>
+        <TableHead>
+          <TableRow>
+            <TableCell sx={{ py: 0.25 }}>Foilhole</TableCell>
+            <TableCell sx={{ py: 0.25 }}>
+              <TableSortLabel
+                active
+                direction={dir}
+                onClick={() => setDir((d) => (d === 'asc' ? 'desc' : 'asc'))}
+              >
+                Quality
+              </TableSortLabel>
+            </TableCell>
+            <TableCell sx={{ py: 0.25 }}>Status</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {rows.map((fh) => (
+            <TableRow key={fh.uuid}>
+              <TableCell sx={{ py: 0.25 }}>
+                <Typography variant="caption">
+                  {fh.foilhole_id}
+                  {fh.is_near_grid_bar ? ' · grid bar' : ''}
                 </Typography>
               </TableCell>
-              <TableCell>
-                <Typography
-                  variant="body2"
-                  sx={{ fontVariantNumeric: 'tabular-nums', color: 'text.secondary' }}
-                >
-                  {sq.magnification != null ? `${(sq.magnification / 1000).toFixed(0)}k` : '--'}
+              <TableCell sx={{ py: 0.25 }}>
+                <Typography variant="caption" sx={{ fontVariantNumeric: 'tabular-nums' }}>
+                  {fh.quality != null ? `${Math.round(fh.quality * 100)}%` : '--'}
+                </Typography>
+              </TableCell>
+              <TableCell sx={{ py: 0.25 }}>
+                <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                  {fh.status}
                 </Typography>
               </TableCell>
             </TableRow>
           ))}
         </TableBody>
       </Table>
-    </TableContainer>
+    </Box>
+  )
+}
+
+function Chevron({ open }: { open: boolean }) {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 16 16"
+      fill="currentColor"
+      role="img"
+      aria-hidden="true"
+      style={{ transform: open ? 'rotate(90deg)' : 'none', transition: 'transform 0.12s' }}
+    >
+      <path d="M6 4l4 4-4 4V4z" />
+    </svg>
   )
 }
 

--- a/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.squares_.$squareId.index.tsx
+++ b/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.squares_.$squareId.index.tsx
@@ -1,11 +1,20 @@
 import {
+  getGetPredictionForGridsquarePredictionModelPredictionModelNameGridsquareGridsquareUuidPredictionGetQueryOptions as squarePredictionQueryOptions,
   useGetGridsquareFoilholesGridsquaresGridsquareUuidFoilholesGet,
   useGetGridsquareGridsquaresGridsquareUuidGet,
+  useGetOverallPredictionForGridsquareGridsquareGridsquareUuidOverallPredictionGet,
+  useGetPredictionModelsPredictionModelsGet,
 } from '@smartem/api'
+import { useQueries } from '@tanstack/react-query'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { useMemo } from 'react'
-import { SquareMap } from '~/components/spatial/SquareMap'
-import { foilHoleResponseToMock, gridSquareResponseToMock } from '~/data/api-adapters'
+import { type PredictionLayer, SquareMap } from '~/components/spatial/SquareMap'
+import {
+  foilHoleResponseToMock,
+  foilholePredictionMap,
+  gridSquareResponseToMock,
+  overallPredictionMap,
+} from '~/data/api-adapters'
 
 export const Route = createFileRoute(
   '/acquisitions/$acquisitionId/grids/$gridId/squares_/$squareId/'
@@ -19,6 +28,9 @@ function SquareIndexView() {
   const { data: squareResponse } = useGetGridsquareGridsquaresGridsquareUuidGet(squareId)
   const { data: foilholeResponses } =
     useGetGridsquareFoilholesGridsquaresGridsquareUuidFoilholesGet(squareId)
+  const { data: modelResponses } = useGetPredictionModelsPredictionModelsGet()
+  const { data: overallResponse } =
+    useGetOverallPredictionForGridsquareGridsquareGridsquareUuidOverallPredictionGet(squareId)
 
   const square = useMemo(
     () => (squareResponse ? gridSquareResponseToMock(squareResponse) : null),
@@ -29,10 +41,41 @@ function SquareIndexView() {
     [foilholeResponses]
   )
 
+  const models = useMemo(() => modelResponses ?? [], [modelResponses])
+
+  // One per-foilhole prediction query per model, scoped to this gridsquare.
+  const predictionResults = useQueries({
+    queries: models.map((m) => squarePredictionQueryOptions(m.name, squareId)),
+  })
+
+  // Assemble the selectable prediction layers (each model that returned data, plus the
+  // cross-model "overall") and their foilhole -> value maps for the square map overlay.
+  const { predictionLayers, predictionValues } = useMemo(() => {
+    const layers: PredictionLayer[] = []
+    const values: Record<string, Map<string, number>> = {}
+    models.forEach((m, i) => {
+      const map = foilholePredictionMap(predictionResults[i]?.data ?? [])
+      if (map.size > 0) {
+        layers.push({ id: m.name, label: m.name.split('-')[0] })
+        values[m.name] = map
+      }
+    })
+    if (overallResponse?.length) {
+      const overall = overallPredictionMap(overallResponse)
+      if (overall.size > 0) {
+        layers.push({ id: 'overall', label: 'Overall' })
+        values.overall = overall
+      }
+    }
+    return { predictionLayers: layers, predictionValues: values }
+  }, [models, predictionResults, overallResponse])
+
   return (
     <SquareMap
       foilholes={foilholes}
       squareLabel={square?.gridsquareId ?? squareId}
+      predictionLayers={predictionLayers}
+      predictionValues={predictionValues}
       onFoilholeClick={(holeUuid) => {
         navigate({
           to: '/acquisitions/$acquisitionId/grids/$gridId/squares/$squareId/holes/$holeId',

--- a/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.squares_.$squareId.predictions.tsx
+++ b/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.squares_.$squareId.predictions.tsx
@@ -1,0 +1,277 @@
+import { Box, ButtonBase, Typography } from '@mui/material'
+import {
+  useGetFoilholeQualityPredictionTimeSeriesForGridsquareGridsquaresGridsquareUuidFoilholeQualityPredictionsGet as useFoilholeSeries,
+  useGetGridsquareQualityPredictionTimeSeriesGridsquaresGridsquareUuidQualityPredictionsGet as useSquareSeries,
+} from '@smartem/api'
+import { createFileRoute } from '@tanstack/react-router'
+import { useMemo, useState } from 'react'
+import { gray, statusColors } from '~/theme'
+import { qualityColor } from '~/utils/heatmap'
+
+export const Route = createFileRoute(
+  '/acquisitions/$acquisitionId/grids/$gridId/squares_/$squareId/predictions'
+)({
+  component: SquarePredictionsView,
+})
+
+function SquarePredictionsView() {
+  const { squareId } = Route.useParams()
+  const { data: squareSeries } = useSquareSeries(squareId)
+  const { data: foilholeSeries } = useFoilholeSeries(squareId)
+
+  // Metric names are the keys of the per-metric time-series responses.
+  const metrics = useMemo(() => {
+    const set = new Set<string>()
+    for (const k of Object.keys(squareSeries ?? {})) set.add(k)
+    for (const k of Object.keys(foilholeSeries ?? {})) set.add(k)
+    return Array.from(set).sort()
+  }, [squareSeries, foilholeSeries])
+
+  const [picked, setPicked] = useState('')
+  const metric = picked && metrics.includes(picked) ? picked : (metrics[0] ?? '')
+
+  const timePoints = useMemo(() => {
+    const arr = [...(squareSeries?.[metric] ?? [])]
+    arr.sort((a, b) => (a.timestamp ?? '').localeCompare(b.timestamp ?? ''))
+    return arr.map((p) => p.value)
+  }, [squareSeries, metric])
+
+  // Latest value per foilhole for the selected metric -> distribution.
+  const foilholeValues = useMemo(() => {
+    const byHole = foilholeSeries?.[metric] ?? {}
+    const vals: number[] = []
+    for (const series of Object.values(byHole)) {
+      if (series.length === 0) continue
+      const latest = [...series].sort((a, b) =>
+        (a.timestamp ?? '').localeCompare(b.timestamp ?? '')
+      )
+      vals.push(latest[latest.length - 1].value)
+    }
+    return vals
+  }, [foilholeSeries, metric])
+
+  const histogram = useMemo(() => {
+    const bins = Array(10).fill(0) as number[]
+    for (const v of foilholeValues) bins[Math.min(9, Math.max(0, Math.floor(v * 10)))]++
+    return bins
+  }, [foilholeValues])
+
+  const squareMean =
+    timePoints.length > 0 ? timePoints.reduce((s, v) => s + v, 0) / timePoints.length : null
+  const foilholeMean =
+    foilholeValues.length > 0
+      ? foilholeValues.reduce((s, v) => s + v, 0) / foilholeValues.length
+      : null
+
+  if (metrics.length === 0) {
+    return (
+      <Box sx={{ p: 3 }}>
+        <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+          No quality predictions recorded for this grid square yet.
+        </Typography>
+      </Box>
+    )
+  }
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'auto', p: 2 }}>
+      {/* Metric selector */}
+      <Box sx={{ display: 'flex', gap: 0.5, mb: 2, flexWrap: 'wrap' }}>
+        {metrics.map((m) => (
+          <ButtonBase
+            key={m}
+            onClick={() => setPicked(m)}
+            sx={{
+              px: 1.5,
+              py: 0.5,
+              borderRadius: 1,
+              fontSize: '0.8125rem',
+              fontWeight: m === metric ? 600 : 400,
+              color: m === metric ? 'text.primary' : 'text.secondary',
+              backgroundColor: m === metric ? gray[50] : 'transparent',
+              '&:hover': { backgroundColor: gray[100] },
+            }}
+          >
+            {m}
+          </ButtonBase>
+        ))}
+      </Box>
+
+      <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
+        <Box
+          sx={{
+            flex: '1 1 480px',
+            border: '1px solid',
+            borderColor: 'divider',
+            borderRadius: 1,
+            p: 2,
+          }}
+        >
+          <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1, mb: 1 }}>
+            <Typography variant="h6">Square quality over time</Typography>
+            {squareMean != null && (
+              <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                mean {Math.round(squareMean * 100)}%
+              </Typography>
+            )}
+          </Box>
+          <LineChart values={timePoints} />
+        </Box>
+
+        <Box
+          sx={{
+            flex: '0 1 360px',
+            border: '1px solid',
+            borderColor: 'divider',
+            borderRadius: 1,
+            p: 2,
+          }}
+        >
+          <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1, mb: 1 }}>
+            <Typography variant="h6">Foilhole distribution</Typography>
+            {foilholeMean != null && (
+              <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                mean {Math.round(foilholeMean * 100)}%
+              </Typography>
+            )}
+          </Box>
+          <Histogram bins={histogram} />
+        </Box>
+      </Box>
+    </Box>
+  )
+}
+
+function LineChart({ values }: { values: number[] }) {
+  if (values.length === 0) {
+    return <EmptyChart label="No time-series for this metric" />
+  }
+  const W = 600
+  const H = 200
+  const pad = { top: 10, right: 10, bottom: 24, left: 36 }
+  const plotW = W - pad.left - pad.right
+  const plotH = H - pad.top - pad.bottom
+  const points = values.map((v, i) => ({
+    x: pad.left + (i / Math.max(1, values.length - 1)) * plotW,
+    y: pad.top + (1 - v) * plotH,
+    v,
+  }))
+  return (
+    <svg
+      viewBox={`0 0 ${W} ${H}`}
+      style={{ width: '100%', height: 'auto' }}
+      role="img"
+      aria-label="Quality over time"
+    >
+      <line
+        x1={pad.left}
+        y1={pad.top}
+        x2={pad.left}
+        y2={pad.top + plotH}
+        stroke={gray[300]}
+        strokeWidth="1"
+      />
+      {[0, 0.5, 1].map((f) => {
+        const y = pad.top + (1 - f) * plotH
+        return (
+          <text key={f} x={pad.left - 6} y={y + 3} textAnchor="end" fontSize="9" fill={gray[500]}>
+            {Math.round(f * 100)}
+          </text>
+        )
+      })}
+      <line
+        x1={pad.left}
+        y1={pad.top + plotH}
+        x2={pad.left + plotW}
+        y2={pad.top + plotH}
+        stroke={gray[300]}
+        strokeWidth="1"
+      />
+      <polyline
+        points={points.map((p) => `${p.x},${p.y}`).join(' ')}
+        fill="none"
+        stroke={statusColors.idle}
+        strokeWidth="1.5"
+        opacity="0.6"
+      />
+      {points.map((p) => (
+        <circle
+          key={`${p.x}-${p.y}`}
+          cx={p.x}
+          cy={p.y}
+          r={3}
+          fill={qualityColor(p.v)}
+          opacity="0.85"
+        />
+      ))}
+    </svg>
+  )
+}
+
+function Histogram({ bins }: { bins: number[] }) {
+  const maxBin = Math.max(1, ...bins)
+  if (bins.every((b) => b === 0)) {
+    return <EmptyChart label="No foilhole predictions for this metric" />
+  }
+  const W = 400
+  const H = 200
+  const pad = { top: 10, right: 10, bottom: 24, left: 32 }
+  const plotW = W - pad.left - pad.right
+  const plotH = H - pad.top - pad.bottom
+  const barW = plotW / bins.length - 2
+  const bars = bins.map((count, i) => ({
+    edge: i / 10,
+    count,
+    x: pad.left + (i / bins.length) * plotW + 1,
+  }))
+  return (
+    <svg
+      viewBox={`0 0 ${W} ${H}`}
+      style={{ width: '100%', height: 'auto' }}
+      role="img"
+      aria-label="Foilhole quality distribution"
+    >
+      <line
+        x1={pad.left}
+        y1={pad.top}
+        x2={pad.left}
+        y2={pad.top + plotH}
+        stroke={gray[300]}
+        strokeWidth="1"
+      />
+      <line
+        x1={pad.left}
+        y1={pad.top + plotH}
+        x2={pad.left + plotW}
+        y2={pad.top + plotH}
+        stroke={gray[300]}
+        strokeWidth="1"
+      />
+      {bars.map((bar) => {
+        const barH = (bar.count / maxBin) * plotH
+        return (
+          <rect
+            key={bar.edge}
+            x={bar.x}
+            y={pad.top + plotH - barH}
+            width={barW}
+            height={barH}
+            fill={qualityColor(bar.edge + 0.05)}
+            opacity="0.7"
+            rx="1"
+          />
+        )
+      })}
+    </svg>
+  )
+}
+
+function EmptyChart({ label }: { label: string }) {
+  return (
+    <Box sx={{ height: 200, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+      <Typography variant="caption" sx={{ color: 'text.disabled' }}>
+        {label}
+      </Typography>
+    </Box>
+  )
+}

--- a/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.squares_.$squareId.tsx
+++ b/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.squares_.$squareId.tsx
@@ -1,5 +1,6 @@
 import { Box } from '@mui/material'
-import { createFileRoute, Outlet } from '@tanstack/react-router'
+import { createFileRoute, Link, Outlet, useRouterState } from '@tanstack/react-router'
+import { gray } from '~/theme'
 
 export const Route = createFileRoute(
   '/acquisitions/$acquisitionId/grids/$gridId/squares_/$squareId'
@@ -8,9 +9,53 @@ export const Route = createFileRoute(
 })
 
 function SquareLayout() {
+  const { acquisitionId, gridId, squareId } = Route.useParams()
+  const pathname = useRouterState({ select: (s) => s.location.pathname })
+  const onPredictions = pathname.endsWith('/predictions')
+
+  const tabSx = (active: boolean) => ({
+    px: 1.25,
+    py: 0.5,
+    fontSize: '0.8125rem',
+    fontWeight: active ? 600 : 400,
+    color: active ? 'text.primary' : 'text.secondary',
+    textDecoration: 'none',
+    borderBottom: '2px solid',
+    borderColor: active ? 'primary.main' : 'transparent',
+    '&:hover': { color: 'text.primary' },
+  })
+
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden' }}>
-      <Outlet />
+      <Box
+        sx={{
+          display: 'flex',
+          gap: 0.5,
+          px: 2,
+          borderBottom: '1px solid',
+          borderColor: 'divider',
+          backgroundColor: gray[50],
+          flexShrink: 0,
+        }}
+      >
+        <Link
+          to="/acquisitions/$acquisitionId/grids/$gridId/squares/$squareId"
+          params={{ acquisitionId, gridId, squareId }}
+          style={{ textDecoration: 'none' }}
+        >
+          <Box sx={tabSx(!onPredictions)}>Map</Box>
+        </Link>
+        <Link
+          to="/acquisitions/$acquisitionId/grids/$gridId/squares/$squareId/predictions"
+          params={{ acquisitionId, gridId, squareId }}
+          style={{ textDecoration: 'none' }}
+        >
+          <Box sx={tabSx(onPredictions)}>Predictions</Box>
+        </Link>
+      </Box>
+      <Box sx={{ flex: 1, overflow: 'hidden' }}>
+        <Outlet />
+      </Box>
     </Box>
   )
 }

--- a/apps/smartem/src/routes/models.$modelName.tsx
+++ b/apps/smartem/src/routes/models.$modelName.tsx
@@ -8,6 +8,7 @@ import {
 import { createFileRoute, Link } from '@tanstack/react-router'
 import { useMemo, useState } from 'react'
 import { WeightsMatrix } from '~/components/weights/WeightsMatrix'
+import { WeightsTimeline } from '~/components/weights/WeightsTimeline'
 import { gray, statusColors } from '~/theme'
 
 export const Route = createFileRoute('/models/$modelName')({
@@ -100,7 +101,7 @@ function ModelDetail() {
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mb: 2, flexWrap: 'wrap' }}>
           <Typography variant="h6">Metric weights</Typography>
           <Typography variant="body2" sx={{ color: 'text.secondary' }}>
-            latest recorded weight per metric for the selected grid
+            weight history and latest values for the selected grid
           </Typography>
           <Box sx={{ flex: 1 }} />
           <Typography variant="caption" sx={{ color: 'text.secondary' }}>
@@ -131,7 +132,10 @@ function ModelDetail() {
         </Box>
 
         {gridUuid ? (
-          <WeightsMatrix weightsByModel={weightsForModel} />
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+            <WeightsTimeline weights={weightsData?.[modelName] ?? []} />
+            <WeightsMatrix weightsByModel={weightsForModel} />
+          </Box>
         ) : (
           <Typography variant="body2" sx={{ color: 'text.secondary' }}>
             No grids available to show weights for.


### PR DESCRIPTION
First batch of legacy feature-parity work from #111 (all buildable without prod images). No backend changes.

## Changes

1. **Square-detail prediction overlay** — `SquareMap` gains prediction layers: each model that returns data, plus the cross-model **Overall**, selectable alongside the intrinsic-metric control and colouring foilholes by predicted quality. The square route fans out one per-foilhole prediction query per model (`useQueries`) + the overall query.
2. **Model weight evolution** — a bespoke SVG `WeightsTimeline` (one line per metric over time, with per-metric mean / current-trend / σ + confidence label) above the latest-values matrix on `/models/$modelName`. Kept dependency-free (no charting lib) to match the app's hand-rolled charts and not pre-empt the open charting-library decision. Closes the time-series remainder of **#67**.
3. **Expandable foilhole table** — each grid-squares row gains a chevron that lazily loads its foilholes into a nested table (sortable by quality) with a weighted-quality aggregate header. Row-click still navigates to the square detail.
4. **Square-level per-metric predictions view (closes #69)** — a new `…/squares/$squareId/predictions` sub-route with a metric selector (driven by the metric-keyed endpoints), a square quality-over-time line chart and a foilhole quality-distribution histogram, each with a mean readout. A **Map | Predictions** tab bar on the square layout switches between the spatial map and this view, mirroring the legacy square predictions page.
5. **Palette deep-link** — now that the model detail route exists (#110), the command palette's Models results jump straight to `/models/$modelName`.

## Verification

Mock mode, headless browser, **zero console/page errors** across all views:
- Square detail: foilhole map + prediction-layer selector (model layers + **Overall**).
- Squares table: expanding a row loads the nested foilhole sub-table.
- Square predictions: Map↔Predictions tabs, metric selector, both charts render (with graceful empty-states under mock faker).
- Model detail: weight timeline renders.

Screenshots: `tmp/verify-square-overlay.png`, `tmp/verify-squares-expand.png`, `tmp/verify-square-predictions.png`, `tmp/verify-weights-timeline.png`.

**Caveat (unchanged, pre-existing):** mock MSW returns un-joined UUIDs / mismatched metric keys, so some overlays/charts show empty/grey in mock mode; they populate against a backend whose data is keyed to the same identifiers.

## Not in this PR

- Atlas "suggested squares" highlighting — buildable now, separate change.
- Real image backgrounds + grid-square gallery — gated on prod imagery (#68).
- Workspace configurability; square-level latent-space scatter — deferred.

Closes #69. Refs #111, #67.
