### PR TITLE
feat(smartem): highlight suggested squares on the atlas

### DIFF
--- a/apps/smartem/src/components/spatial/AtlasMap.tsx
+++ b/apps/smartem/src/components/spatial/AtlasMap.tsx
@@ -23,6 +23,7 @@ interface AtlasMapProps {
   onSquareClick: (squareUuid: string) => void
   predictions?: MockModelPredictions[]
   models?: MockPredictionModel[]
+  suggestedSquareIds?: Set<string>
   selectedSquareId?: string | null
   onSquareHover?: (squareUuid: string | null) => void
   frozenSelection?: boolean
@@ -35,6 +36,7 @@ export function AtlasMap({
   onSquareClick,
   predictions,
   models,
+  suggestedSquareIds,
   selectedSquareId: externalSelectedId,
   onSquareHover,
   frozenSelection: externalFrozen,
@@ -45,6 +47,7 @@ export function AtlasMap({
   const [internalFrozen, setInternalFrozen] = useState(false)
   const [tooltipPos, setTooltipPos] = useState({ x: 0, y: 0 })
   const [showPredictions, setShowPredictions] = useState(false)
+  const [showSuggestions, setShowSuggestions] = useState(false)
   const [selectedModelId, setSelectedModelId] = useState(models?.[0]?.id ?? '')
   const [colorMode, setColorMode] = useState<ColorMode>('quality')
 
@@ -194,6 +197,7 @@ export function AtlasMap({
           {squares.map((sq) => {
             const isHovered = hoveredId === sq.uuid
             const isSelected = selectedId === sq.uuid
+            const isSuggested = showSuggestions && (suggestedSquareIds?.has(sq.uuid) ?? false)
             const fill = getFill(sq)
             const r = getRadius(sq)
             const opacity = isHovered || isSelected ? 1.0 : sq.selected ? 0.8 : 0.5
@@ -207,8 +211,10 @@ export function AtlasMap({
                 r={r}
                 fill={fill}
                 opacity={opacity}
-                stroke={isSelected ? '#e59344' : isHovered ? gray[900] : 'none'}
-                strokeWidth={isSelected ? 12 : isHovered ? 8 : 0}
+                stroke={
+                  isSelected ? '#e59344' : isHovered ? gray[900] : isSuggested ? '#2f6feb' : 'none'
+                }
+                strokeWidth={isSelected ? 12 : isHovered ? 8 : isSuggested ? 10 : 0}
                 style={{ cursor: 'pointer', transition: 'opacity 0.1s' }}
                 onMouseEnter={() => handleHover(sq.uuid)}
                 onMouseLeave={() => handleHover(null)}
@@ -352,6 +358,24 @@ export function AtlasMap({
             }}
           >
             Clusters
+          </ButtonBase>
+        )}
+
+        {suggestedSquareIds && suggestedSquareIds.size > 0 && (
+          <ButtonBase
+            onClick={() => setShowSuggestions((s) => !s)}
+            sx={{
+              px: 0.75,
+              py: 0.25,
+              borderRadius: 0.5,
+              fontSize: '0.625rem',
+              fontWeight: showSuggestions ? 600 : 400,
+              color: showSuggestions ? '#2f6feb' : 'text.disabled',
+              backgroundColor: showSuggestions ? gray[50] : 'transparent',
+              '&:hover': { backgroundColor: gray[100] },
+            }}
+          >
+            Suggestions ({suggestedSquareIds.size})
           </ButtonBase>
         )}
 

--- a/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.atlas.tsx
+++ b/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.atlas.tsx
@@ -5,6 +5,7 @@ import {
   useGetGridGridsGridUuidGet,
   useGetGridGridsquaresGridsGridUuidGridsquaresGet,
   useGetPredictionModelsPredictionModelsGet,
+  useGetSuggestedSquareCollectionsGridGridUuidPredictionModelPredictionModelNameLatentRepLatentRepModelNameSuggestedSquaresGet as useSuggestedSquares,
 } from '@smartem/api'
 import { useQueries } from '@tanstack/react-query'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
@@ -57,6 +58,23 @@ function AtlasView() {
         predictionResponsesToMockPredictions(m.id, gridId, predictionResults[i]?.data ?? [])
       ),
     [models, gridId, predictionResults]
+  )
+
+  // Squares the system suggests collecting next. The endpoint needs a prediction model and a
+  // separate latent-rep model; the API doesn't expose model types, so we default to the first
+  // model for prediction and the second (if any) for the latent representation. A proper
+  // model-type distinction is tracked in #111.
+  const predictionModelName = models[0]?.id ?? ''
+  const latentModelName = models[1]?.id ?? models[0]?.id ?? ''
+  const { data: suggestedSquares } = useSuggestedSquares(
+    gridId,
+    predictionModelName,
+    latentModelName,
+    { query: { enabled: !!predictionModelName } }
+  )
+  const suggestedSquareIds = useMemo(
+    () => new Set((suggestedSquares ?? []).map((s) => s.uuid)),
+    [suggestedSquares]
   )
 
   // Latent representation comes from a specific latent-rep model; lacking a picker, use the
@@ -127,6 +145,7 @@ function AtlasView() {
           onSquareClick={handleSquareNavigate}
           predictions={predictions}
           models={models}
+          suggestedSquareIds={suggestedSquareIds}
           selectedSquareId={selectedSquareId}
           onSquareHover={(id) => {
             if (!frozen) setSelectedSquareId(id)


### PR DESCRIPTION
The last buildable-now legacy-parity item from #111.

## Change

Adds a **Suggestions** toggle to the atlas controls that blue-strokes the grid squares returned by the suggested-squares endpoint (`/grid/{id}/prediction_model/{m}/latent_rep/{l}/suggested_squares`). The toggle only appears when suggestions are available, and the highlight composes with the existing selection/hover strokes.

The endpoint needs a prediction model **and** a separate latent-rep model. The API doesn't expose model types, so rather than hardcoding specific names (as the legacy view did with `resnet-atlas`/`dae-atlas`), this defaults to the first registered model for the prediction and the second (if any) for the latent representation. A proper model-type distinction (or explicit pickers) is noted for follow-up in #111.

## Verification

Mock mode, headless browser, **zero console errors**: the `Suggestions (N)` toggle renders in the atlas controls and toggles cleanly. (Highlight isn't visible under mock faker since the returned UUIDs don't match the grid's squares — the usual faker-join caveat; it lights up against real data.)

Screenshot: `tmp/verify-suggestions.png`.

Refs #111.
