### PR TITLE
feat(smartem): render real images + release 0.3.0

### DIFF
--- a/apps/smartem/package.json
+++ b/apps/smartem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartem/app",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/smartem/src/components/spatial/AtlasMap.tsx
+++ b/apps/smartem/src/components/spatial/AtlasMap.tsx
@@ -20,6 +20,7 @@ type ColorMode = 'quality' | 'prediction' | 'cluster'
 interface AtlasMapProps {
   squares: MockGridSquare[]
   gridName: string
+  imageUrl?: string
   onSquareClick: (squareUuid: string) => void
   predictions?: MockModelPredictions[]
   models?: MockPredictionModel[]
@@ -33,6 +34,7 @@ interface AtlasMapProps {
 export function AtlasMap({
   squares,
   gridName,
+  imageUrl,
   onSquareClick,
   predictions,
   models,
@@ -194,6 +196,16 @@ export function AtlasMap({
             setTooltipPos({ x: e.clientX - rect.left, y: e.clientY - rect.top })
           }}
         >
+          {imageUrl && (
+            <image
+              href={imageUrl}
+              x="0"
+              y="0"
+              width="4005"
+              height="4005"
+              preserveAspectRatio="none"
+            />
+          )}
           {squares.map((sq) => {
             const isHovered = hoveredId === sq.uuid
             const isSelected = selectedId === sq.uuid

--- a/apps/smartem/src/components/spatial/SquareMap.tsx
+++ b/apps/smartem/src/components/spatial/SquareMap.tsx
@@ -49,6 +49,7 @@ export interface PredictionLayer {
 interface SquareMapProps {
   foilholes: MockFoilHole[]
   squareLabel: string
+  imageUrl?: string
   onFoilholeClick?: (uuid: string) => void
   predictionLayers?: PredictionLayer[]
   // layer id -> (foilhole uuid -> predicted value, 0..1)
@@ -58,6 +59,7 @@ interface SquareMapProps {
 export function SquareMap({
   foilholes,
   squareLabel,
+  imageUrl,
   onFoilholeClick,
   predictionLayers = [],
   predictionValues = {},
@@ -204,6 +206,16 @@ export function SquareMap({
             })
           }}
         >
+          {imageUrl && (
+            <image
+              href={imageUrl}
+              x="0"
+              y="0"
+              width="2880"
+              height="2046"
+              preserveAspectRatio="none"
+            />
+          )}
           {foilholes.map((fh) => {
             const isHovered = hoveredId === fh.uuid
             const isSelected = selectedId === fh.uuid

--- a/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.atlas.tsx
+++ b/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.atlas.tsx
@@ -1,5 +1,6 @@
 import { Box, IconButton, Tooltip, Typography } from '@mui/material'
 import {
+  apiUrl,
   getGetPredictionForGridPredictionModelPredictionModelNameGridGridUuidPredictionGetQueryOptions as gridPredictionQueryOptions,
   getGetLatentRepPredictionModelPredictionModelNameGridGridUuidLatentRepresentationGetQueryOptions as latentRepQueryOptions,
   useGetGridGridsGridUuidGet,
@@ -142,6 +143,7 @@ function AtlasView() {
         <AtlasMap
           squares={squares}
           gridName={grid?.name ?? gridId}
+          imageUrl={`${apiUrl()}/grids/${gridId}/atlas_image`}
           onSquareClick={handleSquareNavigate}
           predictions={predictions}
           models={models}

--- a/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.squares_.$squareId.index.tsx
+++ b/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.squares_.$squareId.index.tsx
@@ -1,4 +1,5 @@
 import {
+  apiUrl,
   getGetPredictionForGridsquarePredictionModelPredictionModelNameGridsquareGridsquareUuidPredictionGetQueryOptions as squarePredictionQueryOptions,
   useGetGridsquareFoilholesGridsquaresGridsquareUuidFoilholesGet,
   useGetGridsquareGridsquaresGridsquareUuidGet,
@@ -74,6 +75,7 @@ function SquareIndexView() {
     <SquareMap
       foilholes={foilholes}
       squareLabel={square?.gridsquareId ?? squareId}
+      imageUrl={`${apiUrl()}/gridsquares/${squareId}/gridsquare_image`}
       predictionLayers={predictionLayers}
       predictionValues={predictionValues}
       onFoilholeClick={(holeUuid) => {

--- a/apps/smartem/src/version.ts
+++ b/apps/smartem/src/version.ts
@@ -1,3 +1,3 @@
 // Must stay in sync with the version field in apps/smartem/package.json.
 // The release workflow validates the two values match before building.
-export const FRONTEND_VERSION = '0.2.3' as const
+export const FRONTEND_VERSION = '0.3.0' as const


### PR DESCRIPTION
Renders the real microscopy images and cuts the **0.3.0** release so Dan can deploy and validate the new frontend against prod data.

## Changes

- **Real images** — `AtlasMap` and `SquareMap` now draw the actual atlas / grid-square image (via the `atlas_image` / `gridsquare_image` endpoints, built from `apiUrl()`) behind the SVG overlays, replacing the checkered placeholder (kept as a fallback when no image is available). The image fills the map viewBox so the existing square/foilhole overlays sit on top of it.
- **0.3.0 bump** — `apps/smartem/package.json` + `src/version.ts` (kept in sync for the release check).

This was the last legacy-only capability; with it, the new app is at functional parity with legacy (gap check in #111).

## Verification

Mock mode, headless browser, **zero console errors**: both maps render the `<image>` element with overlays intact; under mock the image 404s so the checkered fallback shows. The real images, exact overlay alignment, and the UUID-join-dependent features (heatmaps, latent, weights, suggestions) can only be confirmed against a real backend — which is the point of this prod deploy.

## Release / next steps

Merging to `main` auto-publishes a `0.3.0rc*` container to GHCR (existing release workflow). Dan deploys that RC and validates against prod: images render, overlays align, joins are correct, general parity. On his sign-off → cut stable `0.3.0` and remove `apps/legacy`.

Refs #111, #68.
