### PR TITLE
fix(smartem): fetch atlas & grid-square images with auth

### DIFF
--- a/apps/smartem/src/hooks/useBlobObjectUrl.ts
+++ b/apps/smartem/src/hooks/useBlobObjectUrl.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'react'
+
+// The image routes are auth-protected, but a browser's SVG <image>/<img> load can't
+// carry the bearer token. Callers fetch the image as an authenticated blob (via the
+// generated query hooks, which go through the token-aware axios instance) and pass it
+// here to obtain a short-lived object URL for the element's href/src. The URL is revoked
+// when the blob changes or the component unmounts so blobs don't leak.
+export function useBlobObjectUrl(blob: Blob | null | undefined): string | undefined {
+  const [objectUrl, setObjectUrl] = useState<string>()
+
+  useEffect(() => {
+    if (!blob) {
+      setObjectUrl(undefined)
+      return
+    }
+    const url = URL.createObjectURL(blob)
+    setObjectUrl(url)
+    return () => URL.revokeObjectURL(url)
+  }, [blob])
+
+  return objectUrl
+}

--- a/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.atlas.tsx
+++ b/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.atlas.tsx
@@ -1,11 +1,11 @@
 import { Box, IconButton, Tooltip, Typography } from '@mui/material'
 import {
-  apiUrl,
   getGetPredictionForGridPredictionModelPredictionModelNameGridGridUuidPredictionGetQueryOptions as gridPredictionQueryOptions,
   getGetLatentRepPredictionModelPredictionModelNameGridGridUuidLatentRepresentationGetQueryOptions as latentRepQueryOptions,
   useGetGridGridsGridUuidGet,
   useGetGridGridsquaresGridsGridUuidGridsquaresGet,
   useGetPredictionModelsPredictionModelsGet,
+  useGetGridAtlasImageGridsGridUuidAtlasImageGet as useGridAtlasImage,
   useGetSuggestedSquareCollectionsGridGridUuidPredictionModelPredictionModelNameLatentRepLatentRepModelNameSuggestedSquaresGet as useSuggestedSquares,
 } from '@smartem/api'
 import { useQueries } from '@tanstack/react-query'
@@ -21,6 +21,7 @@ import {
   predictionResponsesToMockPredictions,
 } from '~/data/api-adapters'
 import type { MockLatentCoords } from '~/data/mock-session-detail'
+import { useBlobObjectUrl } from '~/hooks/useBlobObjectUrl'
 import { gray } from '~/theme'
 
 export const Route = createFileRoute('/acquisitions/$acquisitionId/grids/$gridId/atlas')({
@@ -33,6 +34,10 @@ function AtlasView() {
   const { data: gridResponse } = useGetGridGridsGridUuidGet(gridId)
   const { data: squareResponses } = useGetGridGridsquaresGridsGridUuidGridsquaresGet(gridId)
   const { data: modelResponses } = useGetPredictionModelsPredictionModelsGet()
+  // Image route is auth-protected; fetch as an authenticated blob and hand the
+  // <image> element an object URL rather than a token-less direct URL.
+  const { data: atlasImageBlob } = useGridAtlasImage(gridId, undefined)
+  const atlasImageUrl = useBlobObjectUrl(atlasImageBlob as Blob | undefined)
 
   const grid = useMemo(
     () => (gridResponse ? gridResponseToMock(gridResponse) : null),
@@ -143,7 +148,7 @@ function AtlasView() {
         <AtlasMap
           squares={squares}
           gridName={grid?.name ?? gridId}
-          imageUrl={`${apiUrl()}/grids/${gridId}/atlas_image`}
+          imageUrl={atlasImageUrl}
           onSquareClick={handleSquareNavigate}
           predictions={predictions}
           models={models}

--- a/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.squares_.$squareId.index.tsx
+++ b/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.squares_.$squareId.index.tsx
@@ -1,10 +1,10 @@
 import {
-  apiUrl,
   getGetPredictionForGridsquarePredictionModelPredictionModelNameGridsquareGridsquareUuidPredictionGetQueryOptions as squarePredictionQueryOptions,
   useGetGridsquareFoilholesGridsquaresGridsquareUuidFoilholesGet,
   useGetGridsquareGridsquaresGridsquareUuidGet,
   useGetOverallPredictionForGridsquareGridsquareGridsquareUuidOverallPredictionGet,
   useGetPredictionModelsPredictionModelsGet,
+  useGetGridsquareImageGridsquaresGridsquareUuidGridsquareImageGet as useGridsquareImage,
 } from '@smartem/api'
 import { useQueries } from '@tanstack/react-query'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
@@ -16,6 +16,7 @@ import {
   gridSquareResponseToMock,
   overallPredictionMap,
 } from '~/data/api-adapters'
+import { useBlobObjectUrl } from '~/hooks/useBlobObjectUrl'
 
 export const Route = createFileRoute(
   '/acquisitions/$acquisitionId/grids/$gridId/squares_/$squareId/'
@@ -32,6 +33,10 @@ function SquareIndexView() {
   const { data: modelResponses } = useGetPredictionModelsPredictionModelsGet()
   const { data: overallResponse } =
     useGetOverallPredictionForGridsquareGridsquareGridsquareUuidOverallPredictionGet(squareId)
+  // Image route is auth-protected; fetch as an authenticated blob and hand the
+  // <image> element an object URL rather than a token-less direct URL.
+  const { data: squareImageBlob } = useGridsquareImage(squareId)
+  const squareImageUrl = useBlobObjectUrl(squareImageBlob as Blob | undefined)
 
   const square = useMemo(
     () => (squareResponse ? gridSquareResponseToMock(squareResponse) : null),
@@ -75,7 +80,7 @@ function SquareIndexView() {
     <SquareMap
       foilholes={foilholes}
       squareLabel={square?.gridsquareId ?? squareId}
-      imageUrl={`${apiUrl()}/gridsquares/${squareId}/gridsquare_image`}
+      imageUrl={squareImageUrl}
       predictionLayers={predictionLayers}
       predictionValues={predictionValues}
       onFoilholeClick={(holeUuid) => {


### PR DESCRIPTION
## Problem

The atlas and grid-square image routes are auth-protected on the backend (global `Depends(verify_token)`; only `/health`, `/status`, `/openapi.json`, `/docs`, `/redoc` are exempt). The frontend rendered them via a plain SVG `<image href="/api/grids/{id}/atlas_image">`. Browser image loads don't run through the axios client, so they never get the `Authorization: Bearer` header — against an auth-enabled backend the request **401s** and falls back to the checkered placeholder.

In other words, the "real images" path only ever worked with auth disabled or in mock mode. Once real imagery lands in a prod backend (auth on), atlas/square images would still show the placeholder — a latent prod bug hidden behind the currently-missing image files.

## Fix

Fetch the images through the **generated, token-aware** query hooks (`useGetGridAtlasImage…`, `useGetGridsquareImage…`) — orval already generates these with `responseType: 'blob'` via the authenticated axios instance. The returned Blob is converted to a short-lived object URL by a new `useBlobObjectUrl` hook and handed to the existing `<image>` element; the object URL is revoked on change/unmount.

The presentational `AtlasMap`/`SquareMap` components are unchanged — they still take an `imageUrl?: string`; only the two route call sites and the new hook change. The backend stays exactly as is (images correctly remain behind auth — they're proposal/visit-scoped user data).

## Verification

Run locally against a dev k3s backend with auth enabled (Keycloak mock). Before: `GET /api/grids/{id}/atlas_image` → **401, no auth header**. After: the same request carries `Authorization: Bearer …` and reaches the backend (returns 200 with imagery present; locally 500 only because the prod *dump* has the DB rows but not the on-disk MRC files — resolved once real imagery is imported).

## Follow-up

Noted in #111: whatever image-serving layer is eventually chosen (imagor/imgproxy/OpenSeadragon) must support **authenticated** fetches — OpenSeadragon via a custom tile loader that adds the header (fits this approach); signed-URL services would need a different mechanism.