### PR TITLE
feat(square): highlight suggested foilholes in the square view

### DIFF
--- a/apps/smartem/src/components/spatial/SquareMap.tsx
+++ b/apps/smartem/src/components/spatial/SquareMap.tsx
@@ -54,6 +54,8 @@ interface SquareMapProps {
   predictionLayers?: PredictionLayer[]
   // layer id -> (foilhole uuid -> predicted value, 0..1)
   predictionValues?: Record<string, Map<string, number>>
+  // foilholes the system suggests collecting next; highlighted when the toggle is on
+  suggestedHoleIds?: Set<string>
 }
 
 export function SquareMap({
@@ -63,6 +65,7 @@ export function SquareMap({
   onFoilholeClick,
   predictionLayers = [],
   predictionValues = {},
+  suggestedHoleIds,
 }: SquareMapProps) {
   const [hoveredId, setHoveredId] = useState<string | null>(null)
   const [selectedId, setSelectedId] = useState<string | null>(null)
@@ -70,6 +73,7 @@ export function SquareMap({
   const [tooltipPos, setTooltipPos] = useState({ x: 0, y: 0 })
   const [metric, setMetric] = useState<string>('quality')
   const [hideNull, setHideNull] = useState(false)
+  const [showSuggestions, setShowSuggestions] = useState(false)
 
   const predLayerId = metric.startsWith('pred:') ? metric.slice(5) : null
   const isPred = predLayerId !== null
@@ -220,6 +224,7 @@ export function SquareMap({
             const isHovered = hoveredId === fh.uuid
             const isSelected = selectedId === fh.uuid
             const isNull = isNullMetric(fh)
+            const isSuggested = showSuggestions && (suggestedHoleIds?.has(fh.uuid) ?? false)
 
             if (isNull && hideNull) return null
 
@@ -245,9 +250,13 @@ export function SquareMap({
                         ? '#e59344'
                         : isHovered
                           ? gray[900]
-                          : 'none'
+                          : isSuggested
+                            ? '#2f6feb'
+                            : 'none'
                 }
-                strokeWidth={isNull ? 2 : fh.isNearGridBar ? 4 : isHovered || isSelected ? 4 : 0}
+                strokeWidth={
+                  isNull ? 2 : fh.isNearGridBar ? 4 : isHovered || isSelected || isSuggested ? 4 : 0
+                }
                 strokeDasharray={fh.isNearGridBar ? '8 4' : 'none'}
                 strokeOpacity={isNull ? 0.4 : 1}
                 style={{ cursor: 'pointer', transition: 'opacity 0.1s' }}
@@ -389,6 +398,24 @@ export function SquareMap({
             )
           })}
         </Box>
+
+        {suggestedHoleIds && suggestedHoleIds.size > 0 && (
+          <ButtonBase
+            onClick={() => setShowSuggestions((s) => !s)}
+            sx={{
+              px: 0.75,
+              py: 0.25,
+              borderRadius: 0.5,
+              fontSize: '0.625rem',
+              fontWeight: showSuggestions ? 600 : 400,
+              color: showSuggestions ? '#2f6feb' : 'text.disabled',
+              backgroundColor: showSuggestions ? gray[50] : 'transparent',
+              '&:hover': { backgroundColor: gray[100] },
+            }}
+          >
+            Suggestions ({suggestedHoleIds.size})
+          </ButtonBase>
+        )}
 
         {(useHeatmap || isPred) && (
           <FormControlLabel

--- a/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.squares_.$squareId.index.tsx
+++ b/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.squares_.$squareId.index.tsx
@@ -5,6 +5,7 @@ import {
   useGetOverallPredictionForGridsquareGridsquareGridsquareUuidOverallPredictionGet,
   useGetPredictionModelsPredictionModelsGet,
   useGetGridsquareImageGridsquaresGridsquareUuidGridsquareImageGet as useGridsquareImage,
+  useGetSuggestedHoleCollectionsGridsquaresGridsquareUuidPredictionModelPredictionModelNameLatentRepLatentRepModelNameSuggestedHolesGet as useSuggestedHoles,
 } from '@smartem/api'
 import { useQueries } from '@tanstack/react-query'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
@@ -76,6 +77,23 @@ function SquareIndexView() {
     return { predictionLayers: layers, predictionValues: values }
   }, [models, predictionResults, overallResponse])
 
+  // Foilholes the system suggests collecting next. Mirrors the atlas suggested-squares endpoint:
+  // it needs a prediction model and a separate latent-rep model, but the API doesn't expose model
+  // types, so default to the first model for prediction and the second (if any) for the latent
+  // representation. Proper model-type distinction is tracked in #111.
+  const predictionModelName = models[0]?.name ?? ''
+  const latentModelName = models[1]?.name ?? models[0]?.name ?? ''
+  const { data: suggestedHoles } = useSuggestedHoles(
+    squareId,
+    predictionModelName,
+    latentModelName,
+    { query: { enabled: !!predictionModelName } }
+  )
+  const suggestedHoleIds = useMemo(
+    () => new Set((suggestedHoles ?? []).map((h) => h.uuid)),
+    [suggestedHoles]
+  )
+
   return (
     <SquareMap
       foilholes={foilholes}
@@ -83,6 +101,7 @@ function SquareIndexView() {
       imageUrl={squareImageUrl}
       predictionLayers={predictionLayers}
       predictionValues={predictionValues}
+      suggestedHoleIds={suggestedHoleIds}
       onFoilholeClick={(holeUuid) => {
         navigate({
           to: '/acquisitions/$acquisitionId/grids/$gridId/squares/$squareId/holes/$holeId',


### PR DESCRIPTION
## Summary

Wires the `suggested_holes` endpoint (smartem-decisions#296) into the square view, mirroring how `suggested_squares` is surfaced in the atlas view.

- New **`Suggestions (N)`** toggle in the `SquareMap` footer controls; when on, the suggested foilholes get a blue ring (`#2f6feb`) — the same visual language as the atlas suggested-squares highlight.
- Off by default. The toggle is **hidden when the endpoint returns nothing or isn't deployed yet**, so the square view degrades gracefully.
- Like the atlas endpoint, `suggested_holes` needs a prediction model + a separate latent-rep model; absent a model-type distinction in the API, it defaults to the first model for prediction and the second for the latent representation (tracked in #111).

## Changes

- `SquareMap.tsx`: `suggestedHoleIds?: Set<string>` prop, `showSuggestions` state, blue-ring stroke on suggested circles, and the toggle button (copied from `AtlasMap`).
- `…squares_.$squareId.index.tsx`: call `useGetSuggestedHoleCollections…`, build the id set, pass it down.

## Verification

- `npm run typecheck` -> exit 0; biome clean.
- **Graceful degradation** (real backend, which predates #296): square renders 173 foilholes, `suggested_holes` 404s, the Suggestions toggle is correctly hidden, no console errors.
- **Feature works** (intercepted `suggested_holes` with 6 real foilhole UUIDs): the toggle reads "Suggestions (6)", and turning it on rings exactly those 6 holes in blue (0 before, 6 after).

The live highlight activates once a backend image with #296 is deployed (current dev k3s is a May image).