### PR TITLE
chore(smartem): self-host Inter font, drop Google Fonts CDN

### DIFF
--- a/apps/smartem/index.html
+++ b/apps/smartem/index.html
@@ -3,13 +3,6 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap"
-      crossorigin
-    />
     <link rel="icon" href="/favicon.png" />
     <title>SmartEM</title>
   </head>

--- a/apps/smartem/package.json
+++ b/apps/smartem/package.json
@@ -12,16 +12,17 @@
     "router:generate": "tsr generate"
   },
   "dependencies": {
-    "@smartem/api": "*",
-    "@smartem/ui": "*",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
+    "@fontsource-variable/inter": "^5.2.8",
     "@mui/icons-material": "^7.3.9",
     "@mui/material": "^7.0.2",
-    "keycloak-js": "^26.1.0",
+    "@smartem/api": "*",
+    "@smartem/ui": "*",
     "@tanstack/react-query": "^5.100.6",
     "@tanstack/react-router": "^1.168.3",
     "@tanstack/router-devtools": "^1.166.11",
+    "keycloak-js": "^26.1.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"
   },

--- a/apps/smartem/src/main.tsx
+++ b/apps/smartem/src/main.tsx
@@ -4,6 +4,10 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { AuthGate, type RuntimeConfig, setRuntimeConfig } from './auth'
 import { routeTree } from './routeTree.gen'
+// Self-hosted Inter (variable, optical-size + weight axes, upright + italic) - no
+// runtime Google Fonts CDN dependency. Matches the axes the CDN <link> used to serve.
+import '@fontsource-variable/inter/opsz.css'
+import '@fontsource-variable/inter/opsz-italic.css'
 import './app.css'
 
 const router = createRouter({ routeTree })

--- a/apps/smartem/src/theme.ts
+++ b/apps/smartem/src/theme.ts
@@ -50,7 +50,7 @@ const theme = createTheme({
     },
   },
   typography: {
-    fontFamily: '"Inter", ui-sans-serif, system-ui, sans-serif',
+    fontFamily: '"Inter Variable", "Inter", ui-sans-serif, system-ui, sans-serif',
     fontSize: 13,
     htmlFontSize: 16,
     h1: { fontSize: '1.75rem', fontWeight: 600, letterSpacing: '-0.01em', lineHeight: 1.25 },

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,9 +54,11 @@
     },
     "apps/smartem": {
       "name": "@smartem/app",
+      "version": "0.3.0",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
+        "@fontsource-variable/inter": "^5.2.8",
         "@mui/icons-material": "^7.3.9",
         "@mui/material": "^7.0.2",
         "@smartem/api": "*",
@@ -439,9 +441,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -459,9 +458,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -479,9 +475,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -499,9 +492,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -1192,6 +1182,15 @@
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || ^23.5.0 || >=24.0.0",
         "npm": ">=10"
+      }
+    },
+    "node_modules/@fontsource-variable/inter": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/inter/-/inter-5.2.8.tgz",
+      "integrity": "sha512-kOfP2D+ykbcX/P3IFnokOhVRNoTozo5/JxhAIVYLpea/UBmCQ/YWPBfWIDuBImXX/15KH+eKh4xpEUyS2sQQGQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@gerrit0/mini-shiki": {
@@ -2033,9 +2032,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2053,9 +2049,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2073,9 +2066,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2093,9 +2083,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2113,9 +2100,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2133,9 +2117,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2535,9 +2516,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2555,9 +2533,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2575,9 +2550,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2595,9 +2567,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5213,9 +5182,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5237,9 +5203,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5261,9 +5224,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5285,9 +5245,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5752,8 +5709,10 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "extraneous": true,
+      "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6872,8 +6831,10 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "extraneous": true,
+      "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"


### PR DESCRIPTION
## What

Vendor the **Inter** font locally instead of pulling it from the Google Fonts CDN at runtime.

`apps/smartem/index.html` loaded Inter via `<link>` tags pointing at `fonts.googleapis.com` / `fonts.gstatic.com`, so every page load made third-party requests for the stylesheet and woff2 files. This adds a network dependency outside our control and the usual privacy/availability concerns.

## How

- Add `@fontsource-variable/inter` and import `opsz.css` + `opsz-italic.css` in `main.tsx`.
- These match the axes the CDN was serving: variable Inter, weight `100–900`, optical-size axis, upright + italic, with the same `unicode-range` subsetting.
- Point the MUI theme `fontFamily` at `"Inter Variable"` (Fontsource's family name), keeping `"Inter"` and the system stack as fallbacks.
- Remove the two `preconnect` hints and the CDN stylesheet `<link>` from `index.html`.

Vite fingerprints the woff2 into `dist/assets`, served same-origin — no CDN preconnect/stylesheet remains and no web-server (nginx) change is required.

## Verify

- DevTools → Network filtered to `font`: all requests are same-origin, none to `fonts.g*.com`.
- Typography is unchanged (same family, weights, optical sizing, italics).

Legacy (`apps/legacy`) still uses the CDN but is being retired shortly, so it's intentionally left untouched.