### PR TITLE
feat(spatial): loading indicator + synced image/overlay reveal

### DIFF
--- a/apps/smartem/src/components/spatial/AtlasMap.tsx
+++ b/apps/smartem/src/components/spatial/AtlasMap.tsx
@@ -1,4 +1,11 @@
-import { Box, ButtonBase, FormControlLabel, Switch, Typography } from '@mui/material'
+import {
+  Box,
+  ButtonBase,
+  CircularProgress,
+  FormControlLabel,
+  Switch,
+  Typography,
+} from '@mui/material'
 import { useCallback, useMemo, useState } from 'react'
 import type {
   MockGridSquare,
@@ -21,6 +28,7 @@ interface AtlasMapProps {
   squares: MockGridSquare[]
   gridName: string
   imageUrl?: string
+  imageLoading?: boolean
   onSquareClick: (squareUuid: string) => void
   predictions?: MockModelPredictions[]
   models?: MockPredictionModel[]
@@ -35,6 +43,7 @@ export function AtlasMap({
   squares,
   gridName,
   imageUrl,
+  imageLoading,
   onSquareClick,
   predictions,
   models,
@@ -56,6 +65,19 @@ export function AtlasMap({
   const frozen = externalFrozen ?? internalFrozen
   const selectedId = externalSelectedId ?? internalFrozenId
   const hoveredId = internalHoveredId
+
+  // The atlas image (a multi-MB micrograph decoded server-side) arrives seconds after the
+  // lightweight square geometry. Hold the overlay back until the image has painted so the
+  // circles and image reveal together rather than circles-first. If no image is available,
+  // reveal once we know. Re-arm the reveal when the image changes (e.g. switching grids) by
+  // resetting during render against the previously seen URL - the standard React pattern.
+  const [imageLoaded, setImageLoaded] = useState(false)
+  const [prevImageUrl, setPrevImageUrl] = useState(imageUrl)
+  if (imageUrl !== prevImageUrl) {
+    setPrevImageUrl(imageUrl)
+    setImageLoaded(false)
+  }
+  const imageReady = imageLoaded || (!imageLoading && !imageUrl)
 
   const selectedPrediction = useMemo(
     () => predictions?.find((p) => p.modelId === selectedModelId),
@@ -204,47 +226,86 @@ export function AtlasMap({
               width="4005"
               height="4005"
               preserveAspectRatio="none"
+              onLoad={() => setImageLoaded(true)}
+              onError={() => setImageLoaded(true)}
+              style={{ opacity: imageLoaded ? 1 : 0, transition: 'opacity 0.4s ease' }}
             />
           )}
-          {squares.map((sq) => {
-            const isHovered = hoveredId === sq.uuid
-            const isSelected = selectedId === sq.uuid
-            const isSuggested = showSuggestions && (suggestedSquareIds?.has(sq.uuid) ?? false)
-            const fill = getFill(sq)
-            const r = getRadius(sq)
-            const opacity = isHovered || isSelected ? 1.0 : sq.selected ? 0.8 : 0.5
-            return (
-              <circle
-                key={sq.uuid}
-                role="button"
-                tabIndex={0}
-                cx={sq.centerX}
-                cy={sq.centerY}
-                r={r}
-                fill={fill}
-                opacity={opacity}
-                stroke={
-                  isSelected ? '#e59344' : isHovered ? gray[900] : isSuggested ? '#2f6feb' : 'none'
-                }
-                strokeWidth={isSelected ? 12 : isHovered ? 8 : isSuggested ? 10 : 0}
-                style={{ cursor: 'pointer', transition: 'opacity 0.1s' }}
-                onMouseEnter={() => handleHover(sq.uuid)}
-                onMouseLeave={() => handleHover(null)}
-                onClick={() => handleClick(sq.uuid)}
-                onDoubleClick={() => onSquareClick(sq.uuid)}
-              >
-                {sq.hasImageData && sq.status === 'collected' && (
-                  <animate
-                    attributeName="fill-opacity"
-                    dur="1.5s"
-                    values="0.4;0.9;0.4"
-                    repeatCount="indefinite"
-                  />
-                )}
-              </circle>
-            )
-          })}
+          <g
+            style={{
+              opacity: imageReady ? 1 : 0,
+              transition: 'opacity 0.4s ease',
+              pointerEvents: imageReady ? 'auto' : 'none',
+            }}
+          >
+            {squares.map((sq) => {
+              const isHovered = hoveredId === sq.uuid
+              const isSelected = selectedId === sq.uuid
+              const isSuggested = showSuggestions && (suggestedSquareIds?.has(sq.uuid) ?? false)
+              const fill = getFill(sq)
+              const r = getRadius(sq)
+              const opacity = isHovered || isSelected ? 1.0 : sq.selected ? 0.8 : 0.5
+              return (
+                <circle
+                  key={sq.uuid}
+                  role="button"
+                  tabIndex={0}
+                  cx={sq.centerX}
+                  cy={sq.centerY}
+                  r={r}
+                  fill={fill}
+                  opacity={opacity}
+                  stroke={
+                    isSelected
+                      ? '#e59344'
+                      : isHovered
+                        ? gray[900]
+                        : isSuggested
+                          ? '#2f6feb'
+                          : 'none'
+                  }
+                  strokeWidth={isSelected ? 12 : isHovered ? 8 : isSuggested ? 10 : 0}
+                  style={{ cursor: 'pointer', transition: 'opacity 0.1s' }}
+                  onMouseEnter={() => handleHover(sq.uuid)}
+                  onMouseLeave={() => handleHover(null)}
+                  onClick={() => handleClick(sq.uuid)}
+                  onDoubleClick={() => onSquareClick(sq.uuid)}
+                >
+                  {sq.hasImageData && sq.status === 'collected' && (
+                    <animate
+                      attributeName="fill-opacity"
+                      dur="1.5s"
+                      values="0.4;0.9;0.4"
+                      repeatCount="indefinite"
+                    />
+                  )}
+                </circle>
+              )
+            })}
+          </g>
         </svg>
+
+        {/* Loading indicator while the atlas image is still being fetched/decoded */}
+        {!imageReady && (
+          <Box
+            sx={{
+              position: 'absolute',
+              inset: 0,
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: 1,
+              zIndex: 2,
+              pointerEvents: 'none',
+            }}
+          >
+            <CircularProgress size={28} thickness={4} />
+            <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+              Loading atlas image…
+            </Typography>
+          </Box>
+        )}
 
         {/* Tooltip */}
         {hoveredSquare && (

--- a/apps/smartem/src/components/spatial/SquareMap.tsx
+++ b/apps/smartem/src/components/spatial/SquareMap.tsx
@@ -1,4 +1,11 @@
-import { Box, ButtonBase, Checkbox, FormControlLabel, Typography } from '@mui/material'
+import {
+  Box,
+  ButtonBase,
+  Checkbox,
+  CircularProgress,
+  FormControlLabel,
+  Typography,
+} from '@mui/material'
 import { useCallback, useMemo, useState } from 'react'
 import type { MockFoilHole } from '~/data/mock-session-detail'
 import { gray, statusColors } from '~/theme'
@@ -50,6 +57,7 @@ interface SquareMapProps {
   foilholes: MockFoilHole[]
   squareLabel: string
   imageUrl?: string
+  imageLoading?: boolean
   onFoilholeClick?: (uuid: string) => void
   predictionLayers?: PredictionLayer[]
   // layer id -> (foilhole uuid -> predicted value, 0..1)
@@ -62,6 +70,7 @@ export function SquareMap({
   foilholes,
   squareLabel,
   imageUrl,
+  imageLoading,
   onFoilholeClick,
   predictionLayers = [],
   predictionValues = {},
@@ -74,6 +83,18 @@ export function SquareMap({
   const [metric, setMetric] = useState<string>('quality')
   const [hideNull, setHideNull] = useState(false)
   const [showSuggestions, setShowSuggestions] = useState(false)
+
+  // The micrograph (decoded server-side) lands seconds after the lightweight foilhole geometry.
+  // Hold the overlay back until the image has painted so circles and image reveal together; if
+  // no image is available, reveal once we know. Re-arm on image change by resetting during
+  // render against the previously seen URL - the standard React pattern.
+  const [imageLoaded, setImageLoaded] = useState(false)
+  const [prevImageUrl, setPrevImageUrl] = useState(imageUrl)
+  if (imageUrl !== prevImageUrl) {
+    setPrevImageUrl(imageUrl)
+    setImageLoaded(false)
+  }
+  const imageReady = imageLoaded || (!imageLoading && !imageUrl)
 
   const predLayerId = metric.startsWith('pred:') ? metric.slice(5) : null
   const isPred = predLayerId !== null
@@ -218,55 +239,94 @@ export function SquareMap({
               width="2880"
               height="2046"
               preserveAspectRatio="none"
+              onLoad={() => setImageLoaded(true)}
+              onError={() => setImageLoaded(true)}
+              style={{ opacity: imageLoaded ? 1 : 0, transition: 'opacity 0.4s ease' }}
             />
           )}
-          {foilholes.map((fh) => {
-            const isHovered = hoveredId === fh.uuid
-            const isSelected = selectedId === fh.uuid
-            const isNull = isNullMetric(fh)
-            const isSuggested = showSuggestions && (suggestedHoleIds?.has(fh.uuid) ?? false)
+          <g
+            style={{
+              opacity: imageReady ? 1 : 0,
+              transition: 'opacity 0.4s ease',
+              pointerEvents: imageReady ? 'auto' : 'none',
+            }}
+          >
+            {foilholes.map((fh) => {
+              const isHovered = hoveredId === fh.uuid
+              const isSelected = selectedId === fh.uuid
+              const isNull = isNullMetric(fh)
+              const isSuggested = showSuggestions && (suggestedHoleIds?.has(fh.uuid) ?? false)
 
-            if (isNull && hideNull) return null
+              if (isNull && hideNull) return null
 
-            const fill = isNull ? 'black' : getFill(fh)
-            const opacity = isNull ? 0.2 : isHovered || isSelected ? 1.0 : 0.6
+              const fill = isNull ? 'black' : getFill(fh)
+              const opacity = isNull ? 0.2 : isHovered || isSelected ? 1.0 : 0.6
 
-            return (
-              <circle
-                key={fh.uuid}
-                role="button"
-                tabIndex={0}
-                cx={fh.xLocation}
-                cy={fh.yLocation}
-                r={fh.diameter / 2}
-                fill={fill}
-                opacity={opacity}
-                stroke={
-                  isNull
-                    ? '#cf222e'
-                    : fh.isNearGridBar
-                      ? gray[600]
-                      : isSelected
-                        ? '#e59344'
-                        : isHovered
-                          ? gray[900]
-                          : isSuggested
-                            ? '#2f6feb'
-                            : 'none'
-                }
-                strokeWidth={
-                  isNull ? 2 : fh.isNearGridBar ? 4 : isHovered || isSelected || isSuggested ? 4 : 0
-                }
-                strokeDasharray={fh.isNearGridBar ? '8 4' : 'none'}
-                strokeOpacity={isNull ? 0.4 : 1}
-                style={{ cursor: 'pointer', transition: 'opacity 0.1s' }}
-                onMouseEnter={() => handleHover(fh.uuid)}
-                onMouseLeave={() => handleHover(null)}
-                onClick={() => handleClick(fh.uuid)}
-              />
-            )
-          })}
+              return (
+                <circle
+                  key={fh.uuid}
+                  role="button"
+                  tabIndex={0}
+                  cx={fh.xLocation}
+                  cy={fh.yLocation}
+                  r={fh.diameter / 2}
+                  fill={fill}
+                  opacity={opacity}
+                  stroke={
+                    isNull
+                      ? '#cf222e'
+                      : fh.isNearGridBar
+                        ? gray[600]
+                        : isSelected
+                          ? '#e59344'
+                          : isHovered
+                            ? gray[900]
+                            : isSuggested
+                              ? '#2f6feb'
+                              : 'none'
+                  }
+                  strokeWidth={
+                    isNull
+                      ? 2
+                      : fh.isNearGridBar
+                        ? 4
+                        : isHovered || isSelected || isSuggested
+                          ? 4
+                          : 0
+                  }
+                  strokeDasharray={fh.isNearGridBar ? '8 4' : 'none'}
+                  strokeOpacity={isNull ? 0.4 : 1}
+                  style={{ cursor: 'pointer', transition: 'opacity 0.1s' }}
+                  onMouseEnter={() => handleHover(fh.uuid)}
+                  onMouseLeave={() => handleHover(null)}
+                  onClick={() => handleClick(fh.uuid)}
+                />
+              )
+            })}
+          </g>
         </svg>
+
+        {/* Loading indicator while the micrograph is still being fetched/decoded */}
+        {!imageReady && (
+          <Box
+            sx={{
+              position: 'absolute',
+              inset: 0,
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: 1,
+              zIndex: 2,
+              pointerEvents: 'none',
+            }}
+          >
+            <CircularProgress size={28} thickness={4} />
+            <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+              Loading image…
+            </Typography>
+          </Box>
+        )}
 
         {/* Tooltip */}
         {hoveredHole && (

--- a/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.atlas.tsx
+++ b/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.atlas.tsx
@@ -36,8 +36,15 @@ function AtlasView() {
   const { data: modelResponses } = useGetPredictionModelsPredictionModelsGet()
   // Image route is auth-protected; fetch as an authenticated blob and hand the
   // <image> element an object URL rather than a token-less direct URL.
-  const { data: atlasImageBlob } = useGridAtlasImage(gridId, undefined)
+  const { data: atlasImageBlob, isLoading: atlasImageLoading } = useGridAtlasImage(
+    gridId,
+    undefined
+  )
   const atlasImageUrl = useBlobObjectUrl(atlasImageBlob as Blob | undefined)
+  // "Pending" spans the whole wait: the blob fetch plus the extra tick useBlobObjectUrl needs
+  // to mint the object URL. Without the second term the overlay would briefly flash in between
+  // the fetch resolving and the URL existing.
+  const atlasImagePending = atlasImageLoading || (!!atlasImageBlob && !atlasImageUrl)
 
   const grid = useMemo(
     () => (gridResponse ? gridResponseToMock(gridResponse) : null),
@@ -149,6 +156,7 @@ function AtlasView() {
           squares={squares}
           gridName={grid?.name ?? gridId}
           imageUrl={atlasImageUrl}
+          imageLoading={atlasImagePending}
           onSquareClick={handleSquareNavigate}
           predictions={predictions}
           models={models}

--- a/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.squares_.$squareId.index.tsx
+++ b/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.squares_.$squareId.index.tsx
@@ -36,8 +36,11 @@ function SquareIndexView() {
     useGetOverallPredictionForGridsquareGridsquareGridsquareUuidOverallPredictionGet(squareId)
   // Image route is auth-protected; fetch as an authenticated blob and hand the
   // <image> element an object URL rather than a token-less direct URL.
-  const { data: squareImageBlob } = useGridsquareImage(squareId)
+  const { data: squareImageBlob, isLoading: squareImageLoading } = useGridsquareImage(squareId)
   const squareImageUrl = useBlobObjectUrl(squareImageBlob as Blob | undefined)
+  // "Pending" spans the blob fetch plus the extra tick useBlobObjectUrl needs to mint the
+  // object URL, so the overlay doesn't briefly flash in between the two.
+  const squareImagePending = squareImageLoading || (!!squareImageBlob && !squareImageUrl)
 
   const square = useMemo(
     () => (squareResponse ? gridSquareResponseToMock(squareResponse) : null),
@@ -99,6 +102,7 @@ function SquareIndexView() {
       foilholes={foilholes}
       squareLabel={square?.gridsquareId ?? squareId}
       imageUrl={squareImageUrl}
+      imageLoading={squareImagePending}
       predictionLayers={predictionLayers}
       predictionValues={predictionValues}
       suggestedHoleIds={suggestedHoleIds}


### PR DESCRIPTION
## What

On the **atlas** and **square-detail** spatial maps, the overlay circles painted immediately while the underlying micrograph popped in a few seconds later — with no feedback during the wait. This syncs them: a loading spinner shows until the image is ready, then the image and overlay fade in together.

## Why

The square/foilhole geometry is a small JSON that lands fast, but the atlas/micrograph image is a multi-MB MRC/TIFF the backend decodes to PNG server-side, so it arrives seconds later. Circles-first-then-image looked broken, and there was no loading affordance.

## How

- Track when the SVG `<image>` actually paints (`onLoad`/`onError`).
- Gate the overlay `<g>` and the `<image>` on a shared `imageReady` flag; both fade in together (0.4s).
- `imageReady = imageLoaded || (!imageLoading && !imageUrl)` — reveals once the image paints, *or* once we know there's no image to wait for (404/empty), so it never hangs the spinner.
- Show a `CircularProgress` + caption over the checkered placeholder while `!imageReady`.
- Route-level `pending = isLoading || (blob && !objectUrl)` so "pending" also covers the one-frame gap between the blob fetch resolving and `useBlobObjectUrl` minting the object URL — otherwise the overlay would flash in for a frame, then hide again.
- Overlay is `pointer-events: none` while hidden (no hovering invisible circles), and the reveal re-arms when the image changes (switching grids/squares), via React's render-phase previous-value reset rather than an effect.

## Affected

- `components/spatial/AtlasMap.tsx` + the atlas route
- `components/spatial/SquareMap.tsx` + the square route

## Verify

Open a grid's atlas (or a populated square): a spinner shows over the checkered background, then the image and circles appear together. Grids/squares without an image render the overlay immediately with no spinner hang.