### PR TITLE
ci: bump actions/upload-artifact v5 to v7 in release workflow

### DIFF
--- a/.github/workflows/release-smartem-frontend.yml
+++ b/.github/workflows/release-smartem-frontend.yml
@@ -165,7 +165,7 @@ jobs:
         run: npm run build:smartem
 
       - name: Upload dist
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: smartem-dist
           path: ${{ env.APP_DIR }}/dist


### PR DESCRIPTION
## What

Bump `actions/upload-artifact@v5` → `@v7` in `release-smartem-frontend.yml` (the `Build SPA` job's "Upload dist" step).

## Why

`v5` runs on Node.js 20, which GitHub has deprecated for Actions runners — recent runs emit a deprecation warning. Node 20 defaults flip to Node 24 on **2026-06-02** and Node 20 is removed from runners on **2026-09-16**. `v7` runs on Node 24.

`v7` is already the known-good pin used in `leaked-secrets-scan.yml`, so this just brings the release workflow in line. `setup-node@v6` elsewhere in this workflow already runs on Node 24, so `upload-artifact` was the only laggard.

Closes #102