### PR TITLE
ci: clear remaining Node 20 action deprecations

### DIFF
--- a/.github/workflows/leaked-secrets-scan.yml
+++ b/.github/workflows/leaked-secrets-scan.yml
@@ -32,7 +32,7 @@ jobs:
         run: gitleaks detect --source . --redact -c .gitleaks.toml -v --report-format sarif --report-path gitleaks-report.sarif
       - name: Upload SARIF to code scanning
         if: always()
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: gitleaks-report.sarif
           category: gitleaks

--- a/.github/workflows/release-smartem-frontend.yml
+++ b/.github/workflows/release-smartem-frontend.yml
@@ -271,7 +271,7 @@ jobs:
           echo "body_path=release-notes.md" >> $GITHUB_OUTPUT
 
       - name: Create release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: smartem-frontend-v${{ needs.version.outputs.version }}
           name: smartem-frontend v${{ needs.version.outputs.version }}


### PR DESCRIPTION
## What

Bump the last two actions still running on Node.js 20, so every action across the repo's workflows runs on Node 24.

| Action | Workflow | Change | Why |
|--------|----------|--------|-----|
| `github/codeql-action/upload-sarif` | `leaked-secrets-scan.yml` | `@v3` → `@v4` | Node 20 deprecation **and** a separate "CodeQL Action v3 deprecated Dec 2026, move to v4" warning — v4 clears both |
| `softprops/action-gh-release` | `release-smartem-frontend.yml` | `@v2` → `@v3` | Node 20 deprecation; v3.0.0 is a pure runtime bump (Node 20 → 24), no functional changes |

## How I found them

Pulled the actual warning annotations from the latest run of each workflow (not guessing from version numbers). These two were the only sources; the `osv-scanner` workflow was annotation-clean. Verified each target's `action.yml` declares `using: node24` before bumping.

## Context

Follows #123 (`upload-artifact@v5 → v7`). With this merged, no workflow action emits a Node 20 deprecation warning, ahead of the 2026-06-16 default flip and 2026-09-16 runner removal.