### PR TITLE
feat(smartem): show selected grid square alongside the atlas (#68)

### DIFF
--- a/apps/smartem/.env.example
+++ b/apps/smartem/.env.example
@@ -18,3 +18,7 @@
 # https://DiamondLightSource.github.io/smartem-devtools/operations/kubernetes
 # for the full list of dev stack URLs.
 # VITE_API_PROXY_TARGET=http://localhost:30080
+
+# The TanStack Router + Query devtools float over the bottom corners in dev. They
+# are on by default; set this to false to hide them when they obscure the layout.
+# VITE_DEVTOOLS=false

--- a/apps/smartem/package.json
+++ b/apps/smartem/package.json
@@ -22,7 +22,7 @@
     "@smartem/ui": "*",
     "@tanstack/react-query": "^5.100.6",
     "@tanstack/react-router": "^1.168.3",
-    "@tanstack/router-devtools": "^1.166.11",
+    "@tanstack/react-router-devtools": "^1.166.13",
     "keycloak-js": "^26.1.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"

--- a/apps/smartem/src/components/layout/PaneFrame.tsx
+++ b/apps/smartem/src/components/layout/PaneFrame.tsx
@@ -1,0 +1,118 @@
+import { Box, Typography } from '@mui/material'
+import type { ReactNode } from 'react'
+import { gray } from '~/theme'
+
+// Shared footer-height floor for the two-column panes. Both columns' footers pin to it so their control
+// bars line up the same way the header bars do; the frame owns this so panes can't drift apart.
+export const PANE_FOOTER_MIN_HEIGHT = 60
+
+interface PaneFrameProps {
+  // Header title (bold, single line). `titleMuted` greys it for placeholder panes (e.g. "no selection").
+  title: ReactNode
+  subtitle?: ReactNode
+  titleMuted?: boolean
+  // 3px accent strip down the left of the header; defaults to a neutral grey.
+  accentColor?: string
+  // Right-aligned header slot for icon buttons (expand, close, ...).
+  actions?: ReactNode
+  // Footer content; the frame supplies the height floor, top border and centring, the caller the layout.
+  // Omit for an empty footer bar (kept so the pane stays symmetric with its neighbour).
+  footer?: ReactNode
+  // Canvas colour for the body (e.g. dark matting behind a micrograph). Omit for the default surface.
+  bodyBackground?: string
+  children: ReactNode
+}
+
+// Generic frame for a two-column-view pane: a fixed-height titled header, a flexible body, and a
+// fixed-floor footer. Composing this (rather than re-implementing the chrome per pane) keeps every pane's
+// header and footer aligned with its neighbour structurally instead of by hand.
+export function PaneFrame({
+  title,
+  subtitle,
+  titleMuted,
+  accentColor = gray[400],
+  actions,
+  footer,
+  bodyBackground,
+  children,
+}: PaneFrameProps) {
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden' }}>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 0.5,
+          px: 1.5,
+          py: 1,
+          borderBottom: '1px solid',
+          borderColor: 'divider',
+          backgroundColor: gray[50],
+          flexShrink: 0,
+        }}
+      >
+        <Box
+          sx={{
+            width: '3px',
+            alignSelf: 'stretch',
+            minHeight: 20,
+            borderRadius: 1,
+            backgroundColor: accentColor,
+          }}
+        />
+        <Box sx={{ minWidth: 0, flex: 1 }}>
+          <Typography
+            variant="caption"
+            noWrap
+            sx={{
+              fontWeight: 700,
+              display: 'block',
+              lineHeight: 1.25,
+              color: titleMuted ? 'text.secondary' : 'text.primary',
+            }}
+          >
+            {title}
+          </Typography>
+          {subtitle != null && (
+            <Typography
+              variant="caption"
+              sx={{ color: titleMuted ? 'text.disabled' : 'text.secondary', fontSize: '0.625rem' }}
+            >
+              {subtitle}
+            </Typography>
+          )}
+        </Box>
+        {actions}
+      </Box>
+
+      <Box
+        sx={{
+          flex: 1,
+          minHeight: 0,
+          position: 'relative',
+          overflow: 'hidden',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          ...(bodyBackground ? { backgroundColor: bodyBackground } : {}),
+        }}
+      >
+        {children}
+      </Box>
+
+      <Box
+        sx={{
+          flexShrink: 0,
+          minHeight: PANE_FOOTER_MIN_HEIGHT,
+          borderTop: '1px solid',
+          borderColor: 'divider',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+        }}
+      >
+        {footer}
+      </Box>
+    </Box>
+  )
+}

--- a/apps/smartem/src/components/layout/PaneFrame.tsx
+++ b/apps/smartem/src/components/layout/PaneFrame.tsx
@@ -2,20 +2,19 @@ import { Box, Typography } from '@mui/material'
 import type { ReactNode } from 'react'
 import { gray } from '~/theme'
 
-// Shared footer-height floor for the two-column panes. Both columns' footers pin to it so their control
-// bars line up the same way the header bars do; the frame owns this so panes can't drift apart.
-export const PANE_FOOTER_MIN_HEIGHT = 60
+// Shared footer height for the two-column panes. It is sized to hold the tallest footer (the grid-square
+// panel's two rows) so every pane's footer settles at the same height and its content can be top-aligned
+// across the columns. The frame owns this so the panes can't drift apart.
+export const PANE_FOOTER_MIN_HEIGHT = 72
 
 interface PaneFrameProps {
   // Header title (bold, single line). `titleMuted` greys it for placeholder panes (e.g. "no selection").
   title: ReactNode
   subtitle?: ReactNode
   titleMuted?: boolean
-  // 3px accent strip down the left of the header; defaults to a neutral grey.
-  accentColor?: string
   // Right-aligned header slot for icon buttons (expand, close, ...).
   actions?: ReactNode
-  // Footer content; the frame supplies the height floor, top border and centring, the caller the layout.
+  // Footer content; the frame supplies the height, top border and top-alignment, the caller the layout.
   // Omit for an empty footer bar (kept so the pane stays symmetric with its neighbour).
   footer?: ReactNode
   // Canvas colour for the body (e.g. dark matting behind a micrograph). Omit for the default surface.
@@ -24,13 +23,13 @@ interface PaneFrameProps {
 }
 
 // Generic frame for a two-column-view pane: a fixed-height titled header, a flexible body, and a
-// fixed-floor footer. Composing this (rather than re-implementing the chrome per pane) keeps every pane's
-// header and footer aligned with its neighbour structurally instead of by hand.
+// fixed-height footer. Composing this (rather than re-implementing the chrome per pane) keeps every pane's
+// header and footer aligned with its neighbour structurally instead of by hand. Header title and footer
+// content share the same left margin (px 1.5) so the chrome reads as one consistent indent.
 export function PaneFrame({
   title,
   subtitle,
   titleMuted,
-  accentColor = gray[400],
   actions,
   footer,
   bodyBackground,
@@ -51,15 +50,6 @@ export function PaneFrame({
           flexShrink: 0,
         }}
       >
-        <Box
-          sx={{
-            width: '3px',
-            alignSelf: 'stretch',
-            minHeight: 20,
-            borderRadius: 1,
-            backgroundColor: accentColor,
-          }}
-        />
         <Box sx={{ minWidth: 0, flex: 1 }}>
           <Typography
             variant="caption"
@@ -76,7 +66,12 @@ export function PaneFrame({
           {subtitle != null && (
             <Typography
               variant="caption"
-              sx={{ color: titleMuted ? 'text.disabled' : 'text.secondary', fontSize: '0.625rem' }}
+              noWrap
+              sx={{
+                display: 'block',
+                color: titleMuted ? 'text.disabled' : 'text.secondary',
+                fontSize: '0.625rem',
+              }}
             >
               {subtitle}
             </Typography>
@@ -108,7 +103,7 @@ export function PaneFrame({
           borderColor: 'divider',
           display: 'flex',
           flexDirection: 'column',
-          justifyContent: 'center',
+          justifyContent: 'flex-start',
         }}
       >
         {footer}

--- a/apps/smartem/src/components/spatial/AtlasMap.tsx
+++ b/apps/smartem/src/components/spatial/AtlasMap.tsx
@@ -3,6 +3,8 @@ import {
   ButtonBase,
   CircularProgress,
   FormControlLabel,
+  MenuItem,
+  Select,
   Switch,
   Typography,
 } from '@mui/material'
@@ -73,6 +75,10 @@ export function AtlasMap({
   const selectedId = externalSelectedId ?? internalFrozenId
   const hoveredId = internalHoveredId
 
+  // The model whose predictions colour the overlay. Falls back to the first model so toggling
+  // Predictions on always shows something and the picker never displays an out-of-range value.
+  const effectiveModelId = selectedModelId || models?.[0]?.id || ''
+
   // The atlas image (a multi-MB micrograph decoded server-side) arrives seconds after the
   // lightweight square geometry. Hold the overlay back until the image has painted so the
   // circles and image reveal together rather than circles-first. If no image is available,
@@ -87,8 +93,8 @@ export function AtlasMap({
   const imageReady = imageLoaded || (!imageLoading && !imageUrl)
 
   const selectedPrediction = useMemo(
-    () => predictions?.find((p) => p.modelId === selectedModelId),
-    [predictions, selectedModelId]
+    () => predictions?.find((p) => p.modelId === effectiveModelId),
+    [predictions, effectiveModelId]
   )
 
   const predValues = useMemo(() => {
@@ -192,8 +198,8 @@ export function AtlasMap({
         display: 'flex',
         alignItems: 'center',
         gap: 1,
-        px: 2,
-        py: 0.75,
+        px: 1.5,
+        py: 1,
         flexWrap: 'wrap',
       }}
     >
@@ -219,25 +225,27 @@ export function AtlasMap({
             sx={{ mr: 0.5, ml: 0 }}
           />
           {showPredictions && (
-            <Box sx={{ display: 'flex', gap: 0.25 }}>
-              {models.map((m) => (
-                <ButtonBase
-                  key={m.id}
-                  onClick={() => setSelectedModelId(m.id)}
-                  sx={{
-                    px: 0.75,
-                    py: 0.25,
-                    borderRadius: 0.5,
-                    fontSize: '0.5625rem',
-                    fontWeight: m.id === selectedModelId ? 600 : 400,
-                    color: m.id === selectedModelId ? 'text.primary' : 'text.disabled',
-                    backgroundColor: m.id === selectedModelId ? gray[50] : 'transparent',
-                    '&:hover': { backgroundColor: gray[100] },
-                  }}
-                >
-                  {m.name.split('-')[0]}
-                </ButtonBase>
-              ))}
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+              <Typography variant="caption" sx={{ fontSize: '0.625rem', color: 'text.secondary' }}>
+                Model
+              </Typography>
+              <Select
+                size="small"
+                variant="standard"
+                value={effectiveModelId}
+                onChange={(e) => setSelectedModelId(e.target.value)}
+                sx={{
+                  fontSize: '0.625rem',
+                  maxWidth: 200,
+                  '& .MuiSelect-select': { py: 0.25, pr: 2.5 },
+                }}
+              >
+                {models.map((m) => (
+                  <MenuItem key={m.id} value={m.id} sx={{ fontSize: '0.75rem' }}>
+                    {m.name}
+                  </MenuItem>
+                ))}
+              </Select>
             </Box>
           )}
         </>

--- a/apps/smartem/src/components/spatial/AtlasMap.tsx
+++ b/apps/smartem/src/components/spatial/AtlasMap.tsx
@@ -29,6 +29,10 @@ interface AtlasMapProps {
   gridName: string
   imageUrl?: string
   imageLoading?: boolean
+  // Natural pixel size of the atlas image. Square coords are in this space, so the viewBox must
+  // match it; falls back to a square guess until the image has decoded.
+  imageWidth?: number
+  imageHeight?: number
   onSquareClick: (squareUuid: string) => void
   predictions?: MockModelPredictions[]
   models?: MockPredictionModel[]
@@ -44,6 +48,8 @@ export function AtlasMap({
   gridName,
   imageUrl,
   imageLoading,
+  imageWidth,
+  imageHeight,
   onSquareClick,
   predictions,
   models,
@@ -173,6 +179,12 @@ export function AtlasMap({
 
   const activeMode = showPredictions ? 'prediction' : colorMode
 
+  // Square coords live in the atlas image's native pixel space; match the viewBox to it (falling
+  // back to a square guess until the image decodes) so the overlay sits on the image instead of
+  // being stretched by forcing a non-square image into a square box.
+  const vbW = imageWidth ?? 4005
+  const vbH = imageHeight ?? 4005
+
   return (
     <Box
       sx={{
@@ -202,7 +214,7 @@ export function AtlasMap({
           }}
         />
         <svg
-          viewBox="0 0 4005 4005"
+          viewBox={`0 0 ${vbW} ${vbH}`}
           role="img"
           aria-label="Atlas map showing grid squares"
           style={{
@@ -223,8 +235,8 @@ export function AtlasMap({
               href={imageUrl}
               x="0"
               y="0"
-              width="4005"
-              height="4005"
+              width={vbW}
+              height={vbH}
               preserveAspectRatio="none"
               onLoad={() => setImageLoaded(true)}
               onError={() => setImageLoaded(true)}

--- a/apps/smartem/src/components/spatial/AtlasMap.tsx
+++ b/apps/smartem/src/components/spatial/AtlasMap.tsx
@@ -21,6 +21,7 @@ import {
   qualityColor,
   valueToHeatmapColor,
 } from '~/utils/heatmap'
+import { SPATIAL_FOOTER_MIN_HEIGHT } from './layout'
 
 type ColorMode = 'quality' | 'prediction' | 'cluster'
 
@@ -233,14 +234,12 @@ export function AtlasMap({
 
       <Box
         sx={{
-          // Right-align the atlas image so it butts against the grid-square panel instead of floating
-          // centred; dark canvas matches the panel so the (dark) micrograph blends into the matting.
+          // Dark viewer canvas matching the grid-square panel so the (dark) micrograph blends into the
+          // matting. The image itself is left-aligned inside the SVG (preserveAspectRatio) so it lines up
+          // with the page header; the slack falls to the right, into the seam before the panel.
           flex: 1,
           position: 'relative',
           overflow: 'hidden',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'flex-end',
           backgroundColor: gray[900],
         }}
       >
@@ -259,6 +258,12 @@ export function AtlasMap({
           viewBox={`0 0 ${vbW} ${vbH}`}
           role="img"
           aria-label="Atlas map showing grid squares"
+          // Left-align the scaled image inside the (full-width) SVG so its left edge lines up with the
+          // page header / left margin, consistent with the rest of the page. The SVG fills the pane, so
+          // flex justify-content can't move it - the alignment has to happen inside via
+          // preserveAspectRatio (xMin = left, YMid = vertically centred); the leftover slack falls into
+          // the seam between the atlas and the grid-square panel as dark matting.
+          preserveAspectRatio="xMinYMid meet"
           style={{
             width: '100%',
             height: '100%',
@@ -387,7 +392,7 @@ export function AtlasMap({
         )}
       </Box>
 
-      {/* Controls bar */}
+      {/* Controls bar - shares the grid-square panel's footer height so the two footers line up. */}
       <Box
         sx={{
           display: 'flex',
@@ -395,6 +400,7 @@ export function AtlasMap({
           gap: 1,
           px: 2,
           py: 0.75,
+          minHeight: SPATIAL_FOOTER_MIN_HEIGHT,
           borderTop: '1px solid',
           borderColor: 'divider',
           flexShrink: 0,

--- a/apps/smartem/src/components/spatial/AtlasMap.tsx
+++ b/apps/smartem/src/components/spatial/AtlasMap.tsx
@@ -7,6 +7,7 @@ import {
   Typography,
 } from '@mui/material'
 import { useCallback, useMemo, useState } from 'react'
+import { PaneFrame } from '~/components/layout/PaneFrame'
 import type {
   MockGridSquare,
   MockModelPredictions,
@@ -21,7 +22,6 @@ import {
   qualityColor,
   valueToHeatmapColor,
 } from '~/utils/heatmap'
-import { SPATIAL_FOOTER_MIN_HEIGHT } from './layout'
 
 type ColorMode = 'quality' | 'prediction' | 'cluster'
 
@@ -186,315 +186,258 @@ export function AtlasMap({
   const vbW = imageWidth ?? 4005
   const vbH = imageHeight ?? 4005
 
-  return (
+  const atlasFooter = (
     <Box
       sx={{
         display: 'flex',
-        flexDirection: 'column',
-        height: '100%',
-        overflow: 'hidden',
+        alignItems: 'center',
+        gap: 1,
+        px: 2,
+        py: 0.75,
+        flexWrap: 'wrap',
       }}
     >
-      {/* Header bar - mirrors the grid-square panel header so the two panes line up at the top. */}
-      <Box
-        sx={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 0.5,
-          px: 1.5,
-          py: 1,
-          borderBottom: '1px solid',
-          borderColor: 'divider',
-          backgroundColor: gray[50],
-          flexShrink: 0,
-        }}
-      >
-        <Box
-          sx={{
-            width: '3px',
-            alignSelf: 'stretch',
-            minHeight: 20,
-            borderRadius: 1,
-            backgroundColor: gray[400],
-          }}
-        />
-        <Box sx={{ minWidth: 0, flex: 1 }}>
-          <Typography
-            variant="caption"
-            noWrap
-            sx={{ fontWeight: 700, display: 'block', lineHeight: 1.25 }}
-          >
-            {gridName}
-          </Typography>
-          <Typography variant="caption" sx={{ color: 'text.secondary', fontSize: '0.625rem' }}>
-            {squares.length} squares{frozen ? ' · selection locked' : ''}
-          </Typography>
-        </Box>
-      </Box>
-
-      <Box
-        sx={{
-          // Dark viewer canvas matching the grid-square panel so the (dark) micrograph blends into the
-          // matting. The image itself is left-aligned inside the SVG (preserveAspectRatio) so it lines up
-          // with the page header; the slack falls to the right, into the seam before the panel.
-          flex: 1,
-          position: 'relative',
-          overflow: 'hidden',
-          backgroundColor: gray[900],
-        }}
-      >
-        {/* Checkered placeholder while the atlas image loads; dropped once it is ready. */}
-        {!imageReady && (
-          <Box
-            sx={{
-              position: 'absolute',
-              inset: 0,
-              background: `repeating-conic-gradient(${gray[200]} 0% 25%, ${gray[50]} 0% 50%) 50% / 20px 20px`,
-              borderRadius: 1,
-            }}
+      {/* Prediction overlay toggle */}
+      {models && models.length > 0 && (
+        <>
+          <FormControlLabel
+            control={
+              <Switch
+                size="small"
+                checked={showPredictions}
+                onChange={() => {
+                  setShowPredictions((p) => !p)
+                  setColorMode(showPredictions ? 'quality' : 'prediction')
+                }}
+              />
+            }
+            label={
+              <Typography variant="caption" sx={{ fontSize: '0.625rem' }}>
+                Predictions
+              </Typography>
+            }
+            sx={{ mr: 0.5, ml: 0 }}
           />
-        )}
-        <svg
-          viewBox={`0 0 ${vbW} ${vbH}`}
-          role="img"
-          aria-label="Atlas map showing grid squares"
-          // Left-align the scaled image inside the (full-width) SVG so its left edge lines up with the
-          // page header / left margin, consistent with the rest of the page. The SVG fills the pane, so
-          // flex justify-content can't move it - the alignment has to happen inside via
-          // preserveAspectRatio (xMin = left, YMid = vertically centred); the leftover slack falls into
-          // the seam between the atlas and the grid-square panel as dark matting.
-          preserveAspectRatio="xMinYMid meet"
-          style={{
-            width: '100%',
-            height: '100%',
-            maxWidth: '100%',
-            maxHeight: '100%',
-            position: 'relative',
-            zIndex: 1,
-          }}
-          onMouseMove={(e) => {
-            const rect = e.currentTarget.getBoundingClientRect()
-            setTooltipPos({ x: e.clientX - rect.left, y: e.clientY - rect.top })
+          {showPredictions && (
+            <Box sx={{ display: 'flex', gap: 0.25 }}>
+              {models.map((m) => (
+                <ButtonBase
+                  key={m.id}
+                  onClick={() => setSelectedModelId(m.id)}
+                  sx={{
+                    px: 0.75,
+                    py: 0.25,
+                    borderRadius: 0.5,
+                    fontSize: '0.5625rem',
+                    fontWeight: m.id === selectedModelId ? 600 : 400,
+                    color: m.id === selectedModelId ? 'text.primary' : 'text.disabled',
+                    backgroundColor: m.id === selectedModelId ? gray[50] : 'transparent',
+                    '&:hover': { backgroundColor: gray[100] },
+                  }}
+                >
+                  {m.name.split('-')[0]}
+                </ButtonBase>
+              ))}
+            </Box>
+          )}
+        </>
+      )}
+
+      {/* Color mode: cluster toggle */}
+      {!showPredictions && (
+        <ButtonBase
+          onClick={() => setColorMode((m) => (m === 'cluster' ? 'quality' : 'cluster'))}
+          sx={{
+            px: 0.75,
+            py: 0.25,
+            borderRadius: 0.5,
+            fontSize: '0.625rem',
+            fontWeight: colorMode === 'cluster' ? 600 : 400,
+            color: colorMode === 'cluster' ? 'text.primary' : 'text.disabled',
+            backgroundColor: colorMode === 'cluster' ? gray[50] : 'transparent',
+            '&:hover': { backgroundColor: gray[100] },
           }}
         >
-          {imageUrl && (
-            <image
-              href={imageUrl}
-              x="0"
-              y="0"
-              width={vbW}
-              height={vbH}
-              preserveAspectRatio="none"
-              onLoad={() => setImageLoaded(true)}
-              onError={() => setImageLoaded(true)}
-              style={{ opacity: imageLoaded ? 1 : 0, transition: 'opacity 0.4s ease' }}
-            />
-          )}
-          <g
-            style={{
-              opacity: imageReady ? 1 : 0,
-              transition: 'opacity 0.4s ease',
-              pointerEvents: imageReady ? 'auto' : 'none',
-            }}
-          >
-            {squares.map((sq) => {
-              const isHovered = hoveredId === sq.uuid
-              const isSelected = selectedId === sq.uuid
-              const isSuggested = showSuggestions && (suggestedSquareIds?.has(sq.uuid) ?? false)
-              const fill = getFill(sq)
-              const r = getRadius(sq)
-              const opacity = isHovered || isSelected ? 1.0 : sq.selected ? 0.8 : 0.5
-              return (
-                <circle
-                  key={sq.uuid}
-                  role="button"
-                  tabIndex={0}
-                  cx={sq.centerX}
-                  cy={sq.centerY}
-                  r={r}
-                  fill={fill}
-                  opacity={opacity}
-                  stroke={
-                    isSelected
-                      ? '#e59344'
-                      : isHovered
-                        ? gray[900]
-                        : isSuggested
-                          ? '#2f6feb'
-                          : 'none'
-                  }
-                  strokeWidth={isSelected ? 12 : isHovered ? 8 : isSuggested ? 10 : 0}
-                  style={{ cursor: 'pointer', transition: 'opacity 0.1s' }}
-                  onMouseEnter={() => handleHover(sq.uuid)}
-                  onMouseLeave={() => handleHover(null)}
-                  onClick={() => handleClick(sq.uuid)}
-                  onDoubleClick={() => onSquareClick(sq.uuid)}
-                >
-                  {sq.hasImageData && sq.status === 'collected' && (
-                    <animate
-                      attributeName="fill-opacity"
-                      dur="1.5s"
-                      values="0.4;0.9;0.4"
-                      repeatCount="indefinite"
-                    />
-                  )}
-                </circle>
-              )
-            })}
-          </g>
-        </svg>
+          Clusters
+        </ButtonBase>
+      )}
 
-        {/* Loading indicator while the atlas image is still being fetched/decoded */}
-        {!imageReady && (
-          <Box
-            sx={{
-              position: 'absolute',
-              inset: 0,
-              display: 'flex',
-              flexDirection: 'column',
-              alignItems: 'center',
-              justifyContent: 'center',
-              gap: 1,
-              zIndex: 2,
-              pointerEvents: 'none',
-            }}
-          >
-            <CircularProgress size={28} thickness={4} />
-            <Typography variant="caption" sx={{ color: 'text.secondary' }}>
-              Loading atlas image…
-            </Typography>
-          </Box>
-        )}
+      {suggestedSquareIds && suggestedSquareIds.size > 0 && (
+        <ButtonBase
+          onClick={() => setShowSuggestions((s) => !s)}
+          sx={{
+            px: 0.75,
+            py: 0.25,
+            borderRadius: 0.5,
+            fontSize: '0.625rem',
+            fontWeight: showSuggestions ? 600 : 400,
+            color: showSuggestions ? '#2f6feb' : 'text.disabled',
+            backgroundColor: showSuggestions ? gray[50] : 'transparent',
+            '&:hover': { backgroundColor: gray[100] },
+          }}
+        >
+          Suggestions ({suggestedSquareIds.size})
+        </ButtonBase>
+      )}
 
-        {/* Tooltip */}
-        {hoveredSquare && (
-          <Box
-            sx={{
-              position: 'absolute',
-              left: tooltipPos.x + 12,
-              top: tooltipPos.y - 30,
-              backgroundColor: gray[900],
-              color: '#ffffff',
-              px: 1,
-              py: 0.5,
-              borderRadius: 1,
-              fontSize: '0.75rem',
-              pointerEvents: 'none',
-              whiteSpace: 'nowrap',
-              zIndex: 10,
-            }}
-          >
-            {hoveredSquare.gridsquareId} — {Math.round(hoveredSquare.quality * 100)}%
-            {showPredictions &&
-              predValues?.get(hoveredSquare.uuid) != null &&
-              ` (pred: ${predValues.get(hoveredSquare.uuid)?.toFixed(3)})`}
-          </Box>
-        )}
-      </Box>
+      <Box sx={{ flex: 1 }} />
 
-      {/* Controls bar - shares the grid-square panel's footer height so the two footers line up. */}
-      <Box
-        sx={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 1,
-          px: 2,
-          py: 0.75,
-          minHeight: SPATIAL_FOOTER_MIN_HEIGHT,
-          borderTop: '1px solid',
-          borderColor: 'divider',
-          flexShrink: 0,
-          flexWrap: 'wrap',
+      <ColorLegend mode={activeMode} bins={predBins} />
+    </Box>
+  )
+
+  return (
+    // Dark bodyBackground matches the grid-square panel so the (dark) micrograph blends into the matting.
+    // The image is left-aligned inside the SVG (preserveAspectRatio) so it lines up with the page header;
+    // the slack falls to the right, into the seam before the panel.
+    <PaneFrame
+      title={gridName}
+      subtitle={`${squares.length} squares${frozen ? ' · selection locked' : ''}`}
+      bodyBackground={gray[900]}
+      footer={atlasFooter}
+    >
+      {/* Checkered placeholder while the atlas image loads; dropped once it is ready. */}
+      {!imageReady && (
+        <Box
+          sx={{
+            position: 'absolute',
+            inset: 0,
+            background: `repeating-conic-gradient(${gray[200]} 0% 25%, ${gray[50]} 0% 50%) 50% / 20px 20px`,
+            borderRadius: 1,
+          }}
+        />
+      )}
+      <svg
+        viewBox={`0 0 ${vbW} ${vbH}`}
+        role="img"
+        aria-label="Atlas map showing grid squares"
+        // Left-align the scaled image inside the (full-width) SVG so its left edge lines up with the
+        // page header / left margin, consistent with the rest of the page. The SVG fills the pane, so
+        // flex justify-content can't move it - the alignment has to happen inside via
+        // preserveAspectRatio (xMin = left, YMid = vertically centred); the leftover slack falls into
+        // the seam between the atlas and the grid-square panel as dark matting.
+        preserveAspectRatio="xMinYMid meet"
+        style={{
+          width: '100%',
+          height: '100%',
+          maxWidth: '100%',
+          maxHeight: '100%',
+          position: 'relative',
+          zIndex: 1,
+        }}
+        onMouseMove={(e) => {
+          const rect = e.currentTarget.getBoundingClientRect()
+          setTooltipPos({ x: e.clientX - rect.left, y: e.clientY - rect.top })
         }}
       >
-        {/* Prediction overlay toggle */}
-        {models && models.length > 0 && (
-          <>
-            <FormControlLabel
-              control={
-                <Switch
-                  size="small"
-                  checked={showPredictions}
-                  onChange={() => {
-                    setShowPredictions((p) => !p)
-                    setColorMode(showPredictions ? 'quality' : 'prediction')
-                  }}
-                />
-              }
-              label={
-                <Typography variant="caption" sx={{ fontSize: '0.625rem' }}>
-                  Predictions
-                </Typography>
-              }
-              sx={{ mr: 0.5, ml: 0 }}
-            />
-            {showPredictions && (
-              <Box sx={{ display: 'flex', gap: 0.25 }}>
-                {models.map((m) => (
-                  <ButtonBase
-                    key={m.id}
-                    onClick={() => setSelectedModelId(m.id)}
-                    sx={{
-                      px: 0.75,
-                      py: 0.25,
-                      borderRadius: 0.5,
-                      fontSize: '0.5625rem',
-                      fontWeight: m.id === selectedModelId ? 600 : 400,
-                      color: m.id === selectedModelId ? 'text.primary' : 'text.disabled',
-                      backgroundColor: m.id === selectedModelId ? gray[50] : 'transparent',
-                      '&:hover': { backgroundColor: gray[100] },
-                    }}
-                  >
-                    {m.name.split('-')[0]}
-                  </ButtonBase>
-                ))}
-              </Box>
-            )}
-          </>
+        {imageUrl && (
+          <image
+            href={imageUrl}
+            x="0"
+            y="0"
+            width={vbW}
+            height={vbH}
+            preserveAspectRatio="none"
+            onLoad={() => setImageLoaded(true)}
+            onError={() => setImageLoaded(true)}
+            style={{ opacity: imageLoaded ? 1 : 0, transition: 'opacity 0.4s ease' }}
+          />
         )}
+        <g
+          style={{
+            opacity: imageReady ? 1 : 0,
+            transition: 'opacity 0.4s ease',
+            pointerEvents: imageReady ? 'auto' : 'none',
+          }}
+        >
+          {squares.map((sq) => {
+            const isHovered = hoveredId === sq.uuid
+            const isSelected = selectedId === sq.uuid
+            const isSuggested = showSuggestions && (suggestedSquareIds?.has(sq.uuid) ?? false)
+            const fill = getFill(sq)
+            const r = getRadius(sq)
+            const opacity = isHovered || isSelected ? 1.0 : sq.selected ? 0.8 : 0.5
+            return (
+              <circle
+                key={sq.uuid}
+                role="button"
+                tabIndex={0}
+                cx={sq.centerX}
+                cy={sq.centerY}
+                r={r}
+                fill={fill}
+                opacity={opacity}
+                stroke={
+                  isSelected ? '#e59344' : isHovered ? gray[900] : isSuggested ? '#2f6feb' : 'none'
+                }
+                strokeWidth={isSelected ? 12 : isHovered ? 8 : isSuggested ? 10 : 0}
+                style={{ cursor: 'pointer', transition: 'opacity 0.1s' }}
+                onMouseEnter={() => handleHover(sq.uuid)}
+                onMouseLeave={() => handleHover(null)}
+                onClick={() => handleClick(sq.uuid)}
+                onDoubleClick={() => onSquareClick(sq.uuid)}
+              >
+                {sq.hasImageData && sq.status === 'collected' && (
+                  <animate
+                    attributeName="fill-opacity"
+                    dur="1.5s"
+                    values="0.4;0.9;0.4"
+                    repeatCount="indefinite"
+                  />
+                )}
+              </circle>
+            )
+          })}
+        </g>
+      </svg>
 
-        {/* Color mode: cluster toggle */}
-        {!showPredictions && (
-          <ButtonBase
-            onClick={() => setColorMode((m) => (m === 'cluster' ? 'quality' : 'cluster'))}
-            sx={{
-              px: 0.75,
-              py: 0.25,
-              borderRadius: 0.5,
-              fontSize: '0.625rem',
-              fontWeight: colorMode === 'cluster' ? 600 : 400,
-              color: colorMode === 'cluster' ? 'text.primary' : 'text.disabled',
-              backgroundColor: colorMode === 'cluster' ? gray[50] : 'transparent',
-              '&:hover': { backgroundColor: gray[100] },
-            }}
-          >
-            Clusters
-          </ButtonBase>
-        )}
+      {/* Loading indicator while the atlas image is still being fetched/decoded */}
+      {!imageReady && (
+        <Box
+          sx={{
+            position: 'absolute',
+            inset: 0,
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 1,
+            zIndex: 2,
+            pointerEvents: 'none',
+          }}
+        >
+          <CircularProgress size={28} thickness={4} />
+          <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+            Loading atlas image…
+          </Typography>
+        </Box>
+      )}
 
-        {suggestedSquareIds && suggestedSquareIds.size > 0 && (
-          <ButtonBase
-            onClick={() => setShowSuggestions((s) => !s)}
-            sx={{
-              px: 0.75,
-              py: 0.25,
-              borderRadius: 0.5,
-              fontSize: '0.625rem',
-              fontWeight: showSuggestions ? 600 : 400,
-              color: showSuggestions ? '#2f6feb' : 'text.disabled',
-              backgroundColor: showSuggestions ? gray[50] : 'transparent',
-              '&:hover': { backgroundColor: gray[100] },
-            }}
-          >
-            Suggestions ({suggestedSquareIds.size})
-          </ButtonBase>
-        )}
-
-        <Box sx={{ flex: 1 }} />
-
-        <ColorLegend mode={activeMode} bins={predBins} />
-      </Box>
-    </Box>
+      {/* Tooltip */}
+      {hoveredSquare && (
+        <Box
+          sx={{
+            position: 'absolute',
+            left: tooltipPos.x + 12,
+            top: tooltipPos.y - 30,
+            backgroundColor: gray[900],
+            color: '#ffffff',
+            px: 1,
+            py: 0.5,
+            borderRadius: 1,
+            fontSize: '0.75rem',
+            pointerEvents: 'none',
+            whiteSpace: 'nowrap',
+            zIndex: 10,
+          }}
+        >
+          {hoveredSquare.gridsquareId} — {Math.round(hoveredSquare.quality * 100)}%
+          {showPredictions &&
+            predValues?.get(hoveredSquare.uuid) != null &&
+            ` (pred: ${predValues.get(hoveredSquare.uuid)?.toFixed(3)})`}
+        </Box>
+      )}
+    </PaneFrame>
   )
 }
 

--- a/apps/smartem/src/components/spatial/AtlasMap.tsx
+++ b/apps/smartem/src/components/spatial/AtlasMap.tsx
@@ -194,25 +194,67 @@ export function AtlasMap({
         overflow: 'hidden',
       }}
     >
+      {/* Header bar - mirrors the grid-square panel header so the two panes line up at the top. */}
       <Box
         sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 0.5,
+          px: 1.5,
+          py: 1,
+          borderBottom: '1px solid',
+          borderColor: 'divider',
+          backgroundColor: gray[50],
+          flexShrink: 0,
+        }}
+      >
+        <Box
+          sx={{
+            width: '3px',
+            alignSelf: 'stretch',
+            minHeight: 20,
+            borderRadius: 1,
+            backgroundColor: gray[400],
+          }}
+        />
+        <Box sx={{ minWidth: 0, flex: 1 }}>
+          <Typography
+            variant="caption"
+            noWrap
+            sx={{ fontWeight: 700, display: 'block', lineHeight: 1.25 }}
+          >
+            {gridName}
+          </Typography>
+          <Typography variant="caption" sx={{ color: 'text.secondary', fontSize: '0.625rem' }}>
+            {squares.length} squares{frozen ? ' · selection locked' : ''}
+          </Typography>
+        </Box>
+      </Box>
+
+      <Box
+        sx={{
+          // Right-align the atlas image so it butts against the grid-square panel instead of floating
+          // centred; dark canvas matches the panel so the (dark) micrograph blends into the matting.
           flex: 1,
           position: 'relative',
           overflow: 'hidden',
           display: 'flex',
           alignItems: 'center',
-          justifyContent: 'center',
+          justifyContent: 'flex-end',
+          backgroundColor: gray[900],
         }}
       >
-        {/* Image placeholder background */}
-        <Box
-          sx={{
-            position: 'absolute',
-            inset: 0,
-            background: `repeating-conic-gradient(${gray[200]} 0% 25%, ${gray[50]} 0% 50%) 50% / 20px 20px`,
-            borderRadius: 1,
-          }}
-        />
+        {/* Checkered placeholder while the atlas image loads; dropped once it is ready. */}
+        {!imageReady && (
+          <Box
+            sx={{
+              position: 'absolute',
+              inset: 0,
+              background: `repeating-conic-gradient(${gray[200]} 0% 25%, ${gray[50]} 0% 50%) 50% / 20px 20px`,
+              borderRadius: 1,
+            }}
+          />
+        )}
         <svg
           viewBox={`0 0 ${vbW} ${vbH}`}
           role="img"
@@ -359,28 +401,6 @@ export function AtlasMap({
           flexWrap: 'wrap',
         }}
       >
-        <Typography variant="caption" sx={{ fontWeight: 600 }}>
-          {gridName}
-        </Typography>
-        <Typography variant="caption" sx={{ color: 'text.secondary' }}>
-          {squares.length} squares
-        </Typography>
-
-        {frozen && (
-          <Typography
-            variant="caption"
-            sx={{
-              color: statusColors.paused,
-              fontWeight: 500,
-              fontSize: '0.625rem',
-            }}
-          >
-            selection locked
-          </Typography>
-        )}
-
-        <Box sx={{ flex: 1 }} />
-
         {/* Prediction overlay toggle */}
         {models && models.length > 0 && (
           <>
@@ -463,6 +483,8 @@ export function AtlasMap({
             Suggestions ({suggestedSquareIds.size})
           </ButtonBase>
         )}
+
+        <Box sx={{ flex: 1 }} />
 
         <ColorLegend mode={activeMode} bins={predBins} />
       </Box>

--- a/apps/smartem/src/components/spatial/EmptySquarePanel.tsx
+++ b/apps/smartem/src/components/spatial/EmptySquarePanel.tsx
@@ -7,13 +7,7 @@ import { gray } from '~/theme'
 // by the real grid-square panel without the layout shifting.
 export function EmptySquarePanel() {
   return (
-    <PaneFrame
-      title="Grid square"
-      subtitle="None selected"
-      accentColor={gray[300]}
-      titleMuted
-      bodyBackground={gray[900]}
-    >
+    <PaneFrame title="Grid square" subtitle="None selected" titleMuted bodyBackground={gray[900]}>
       <Typography variant="caption" sx={{ color: gray[500], px: 3, textAlign: 'center' }}>
         Click a square on the atlas to preview it
       </Typography>

--- a/apps/smartem/src/components/spatial/EmptySquarePanel.tsx
+++ b/apps/smartem/src/components/spatial/EmptySquarePanel.tsx
@@ -1,9 +1,11 @@
 import { Box, Typography } from '@mui/material'
 import { gray } from '~/theme'
+import { SPATIAL_FOOTER_MIN_HEIGHT } from './layout'
 
 // Placeholder shown in the persistent right-hand panel before any grid square is selected. It mirrors
-// the SquareMap "panel" frame (matching header height + dark viewer canvas) so the layout does not
-// shift when a square is actually clicked - the panel is simply populated in place.
+// the SquareMap "panel" frame (matching header height + dark viewer canvas + footer bar) so the layout
+// does not shift, and stays symmetric with the atlas pane, before a square is clicked - the panel is
+// simply populated in place.
 export function EmptySquarePanel() {
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden' }}>
@@ -59,6 +61,17 @@ export function EmptySquarePanel() {
           Click a square on the atlas to preview it
         </Typography>
       </Box>
+
+      {/* Empty footer bar matching the atlas footer height/border so the two panes stay symmetric
+          (header / canvas / footer) before any square is selected; populated once one is picked. */}
+      <Box
+        sx={{
+          minHeight: SPATIAL_FOOTER_MIN_HEIGHT,
+          borderTop: '1px solid',
+          borderColor: 'divider',
+          flexShrink: 0,
+        }}
+      />
     </Box>
   )
 }

--- a/apps/smartem/src/components/spatial/EmptySquarePanel.tsx
+++ b/apps/smartem/src/components/spatial/EmptySquarePanel.tsx
@@ -1,77 +1,22 @@
-import { Box, Typography } from '@mui/material'
+import { Typography } from '@mui/material'
+import { PaneFrame } from '~/components/layout/PaneFrame'
 import { gray } from '~/theme'
-import { SPATIAL_FOOTER_MIN_HEIGHT } from './layout'
 
-// Placeholder shown in the persistent right-hand panel before any grid square is selected. It mirrors
-// the SquareMap "panel" frame (matching header height + dark viewer canvas + footer bar) so the layout
-// does not shift, and stays symmetric with the atlas pane, before a square is clicked - the panel is
-// simply populated in place.
+// Placeholder shown in the persistent right-hand panel before any grid square is selected. Composes the
+// shared PaneFrame so it lines up (header / canvas / footer) with the atlas pane and is replaced in place
+// by the real grid-square panel without the layout shifting.
 export function EmptySquarePanel() {
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden' }}>
-      <Box
-        sx={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 0.5,
-          px: 1.5,
-          py: 1,
-          borderBottom: '1px solid',
-          borderColor: 'divider',
-          backgroundColor: gray[50],
-          flexShrink: 0,
-        }}
-      >
-        <Box
-          sx={{
-            width: '3px',
-            alignSelf: 'stretch',
-            minHeight: 20,
-            borderRadius: 1,
-            backgroundColor: gray[300],
-          }}
-        />
-        <Box sx={{ minWidth: 0, flex: 1 }}>
-          <Typography
-            variant="caption"
-            noWrap
-            sx={{ fontWeight: 700, display: 'block', lineHeight: 1.25, color: 'text.secondary' }}
-          >
-            Grid square
-          </Typography>
-          <Typography variant="caption" sx={{ color: 'text.disabled', fontSize: '0.625rem' }}>
-            None selected
-          </Typography>
-        </Box>
-      </Box>
-
-      <Box
-        sx={{
-          flex: 1,
-          minHeight: 0,
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          backgroundColor: gray[900],
-          px: 3,
-          textAlign: 'center',
-        }}
-      >
-        <Typography variant="caption" sx={{ color: gray[500] }}>
-          Click a square on the atlas to preview it
-        </Typography>
-      </Box>
-
-      {/* Empty footer bar matching the atlas footer height/border so the two panes stay symmetric
-          (header / canvas / footer) before any square is selected; populated once one is picked. */}
-      <Box
-        sx={{
-          minHeight: SPATIAL_FOOTER_MIN_HEIGHT,
-          borderTop: '1px solid',
-          borderColor: 'divider',
-          flexShrink: 0,
-        }}
-      />
-    </Box>
+    <PaneFrame
+      title="Grid square"
+      subtitle="None selected"
+      accentColor={gray[300]}
+      titleMuted
+      bodyBackground={gray[900]}
+    >
+      <Typography variant="caption" sx={{ color: gray[500], px: 3, textAlign: 'center' }}>
+        Click a square on the atlas to preview it
+      </Typography>
+    </PaneFrame>
   )
 }

--- a/apps/smartem/src/components/spatial/EmptySquarePanel.tsx
+++ b/apps/smartem/src/components/spatial/EmptySquarePanel.tsx
@@ -1,0 +1,64 @@
+import { Box, Typography } from '@mui/material'
+import { gray } from '~/theme'
+
+// Placeholder shown in the persistent right-hand panel before any grid square is selected. It mirrors
+// the SquareMap "panel" frame (matching header height + dark viewer canvas) so the layout does not
+// shift when a square is actually clicked - the panel is simply populated in place.
+export function EmptySquarePanel() {
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden' }}>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 0.5,
+          px: 1.5,
+          py: 1,
+          borderBottom: '1px solid',
+          borderColor: 'divider',
+          backgroundColor: gray[50],
+          flexShrink: 0,
+        }}
+      >
+        <Box
+          sx={{
+            width: '3px',
+            alignSelf: 'stretch',
+            minHeight: 20,
+            borderRadius: 1,
+            backgroundColor: gray[300],
+          }}
+        />
+        <Box sx={{ minWidth: 0, flex: 1 }}>
+          <Typography
+            variant="caption"
+            noWrap
+            sx={{ fontWeight: 700, display: 'block', lineHeight: 1.25, color: 'text.secondary' }}
+          >
+            Grid square
+          </Typography>
+          <Typography variant="caption" sx={{ color: 'text.disabled', fontSize: '0.625rem' }}>
+            None selected
+          </Typography>
+        </Box>
+      </Box>
+
+      <Box
+        sx={{
+          flex: 1,
+          minHeight: 0,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: gray[900],
+          px: 3,
+          textAlign: 'center',
+        }}
+      >
+        <Typography variant="caption" sx={{ color: gray[500] }}>
+          Click a square on the atlas to preview it
+        </Typography>
+      </Box>
+    </Box>
+  )
+}

--- a/apps/smartem/src/components/spatial/LatentSpacePanel.tsx
+++ b/apps/smartem/src/components/spatial/LatentSpacePanel.tsx
@@ -57,7 +57,7 @@ export function LatentSpacePanel({
   const toSvgY = (y: number) => pad.top + ((maxY - y) / (maxY - minY)) * plotH
 
   const footer = (
-    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, px: 2, py: 0.75 }}>
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, px: 1.5, py: 1 }}>
       <Box sx={{ flex: 1 }} />
       <FormControlLabel
         control={

--- a/apps/smartem/src/components/spatial/LatentSpacePanel.tsx
+++ b/apps/smartem/src/components/spatial/LatentSpacePanel.tsx
@@ -1,5 +1,6 @@
-import { Box, Checkbox, FormControlLabel, Typography } from '@mui/material'
+import { Box, Checkbox, FormControlLabel, IconButton, Typography } from '@mui/material'
 import { useMemo, useState } from 'react'
+import { PaneFrame } from '~/components/layout/PaneFrame'
 import type { MockLatentCoords } from '~/data/mock-session-detail'
 import { gray } from '~/theme'
 import { CLUSTER_PALETTE } from '~/utils/heatmap'
@@ -16,6 +17,8 @@ interface LatentSpacePanelProps {
   selectedId: string | null
   onItemClick?: (id: string) => void
   onItemHover?: (id: string | null) => void
+  // When provided, renders a close button in the pane header (used as the atlas-embedded panel).
+  onClose?: () => void
 }
 
 export function LatentSpacePanel({
@@ -23,6 +26,7 @@ export function LatentSpacePanel({
   selectedId,
   onItemClick,
   onItemHover,
+  onClose,
 }: LatentSpacePanelProps) {
   const [showUnselected, setShowUnselected] = useState(true)
 
@@ -52,97 +56,81 @@ export function LatentSpacePanel({
   const toSvgX = (x: number) => pad.left + ((x - minX) / (maxX - minX)) * plotW
   const toSvgY = (y: number) => pad.top + ((maxY - y) / (maxY - minY)) * plotH
 
-  return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden' }}>
-      <Box
-        sx={{
-          flex: 1,
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          overflow: 'hidden',
-        }}
-      >
-        <svg
-          viewBox={`0 0 ${W} ${H}`}
-          role="img"
-          aria-label="Latent space scatter plot"
-          style={{
-            width: '100%',
-            height: '100%',
-            maxWidth: '100%',
-            maxHeight: '100%',
-            background: gray[900],
-            borderRadius: 4,
-          }}
-        >
-          {items.map((item) => {
-            const isSelected = item.id === selectedId
-            if (!showUnselected && !isSelected) return null
-            const cx = toSvgX(item.latent.x)
-            const cy = toSvgY(item.latent.y)
-            const clusterColor = CLUSTER_PALETTE[item.latent.clusterIndex % CLUSTER_PALETTE.length]
-            const r = item.predictionValue != null ? 3 + item.predictionValue * 5 : 5
-            return (
-              <circle
-                key={item.id}
-                role="button"
-                tabIndex={0}
-                cx={cx}
-                cy={cy}
-                r={isSelected ? r + 2 : r}
-                fill={isSelected ? '#ffffff' : clusterColor}
-                opacity={isSelected ? 1 : 0.75}
-                stroke={isSelected ? '#ffffff' : 'none'}
-                strokeWidth={isSelected ? 2 : 0}
-                style={{ cursor: 'pointer', transition: 'r 0.15s, fill 0.15s' }}
-                onClick={() => onItemClick?.(item.id)}
-                onMouseEnter={() => onItemHover?.(item.id)}
-                onMouseLeave={() => onItemHover?.(null)}
-              />
-            )
-          })}
-        </svg>
-      </Box>
-
-      <Box
-        sx={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 1,
-          px: 2,
-          py: 0.75,
-          borderTop: '1px solid',
-          borderColor: 'divider',
-          flexShrink: 0,
-        }}
-      >
-        <Typography variant="caption" sx={{ fontWeight: 600 }}>
-          Latent Space
-        </Typography>
-        <Typography variant="caption" sx={{ color: 'text.secondary' }}>
-          {items.length} points
-        </Typography>
-        <Box sx={{ flex: 1 }} />
-        <FormControlLabel
-          control={
-            <Checkbox
-              size="small"
-              checked={showUnselected}
-              onChange={(e) => setShowUnselected(e.target.checked)}
-              sx={{ p: 0.25 }}
-            />
-          }
-          label={
-            <Typography variant="caption" sx={{ fontSize: '0.625rem' }}>
-              Show all
-            </Typography>
-          }
-          sx={{ mr: 0 }}
-        />
-        <ClusterLegend />
-      </Box>
+  const footer = (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, px: 2, py: 0.75 }}>
+      <Box sx={{ flex: 1 }} />
+      <FormControlLabel
+        control={
+          <Checkbox
+            size="small"
+            checked={showUnselected}
+            onChange={(e) => setShowUnselected(e.target.checked)}
+            sx={{ p: 0.25 }}
+          />
+        }
+        label={
+          <Typography variant="caption" sx={{ fontSize: '0.625rem' }}>
+            Show all
+          </Typography>
+        }
+        sx={{ mr: 0 }}
+      />
+      <ClusterLegend />
     </Box>
+  )
+
+  return (
+    <PaneFrame
+      title="Latent Space"
+      subtitle={`${items.length} points`}
+      bodyBackground={gray[900]}
+      actions={onClose ? <CloseButton onClick={onClose} /> : undefined}
+      footer={footer}
+    >
+      <svg
+        viewBox={`0 0 ${W} ${H}`}
+        role="img"
+        aria-label="Latent space scatter plot"
+        style={{ width: '100%', height: '100%', maxWidth: '100%', maxHeight: '100%' }}
+      >
+        {items.map((item) => {
+          const isSelected = item.id === selectedId
+          if (!showUnselected && !isSelected) return null
+          const cx = toSvgX(item.latent.x)
+          const cy = toSvgY(item.latent.y)
+          const clusterColor = CLUSTER_PALETTE[item.latent.clusterIndex % CLUSTER_PALETTE.length]
+          const r = item.predictionValue != null ? 3 + item.predictionValue * 5 : 5
+          return (
+            <circle
+              key={item.id}
+              role="button"
+              tabIndex={0}
+              cx={cx}
+              cy={cy}
+              r={isSelected ? r + 2 : r}
+              fill={isSelected ? '#ffffff' : clusterColor}
+              opacity={isSelected ? 1 : 0.75}
+              stroke={isSelected ? '#ffffff' : 'none'}
+              strokeWidth={isSelected ? 2 : 0}
+              style={{ cursor: 'pointer', transition: 'r 0.15s, fill 0.15s' }}
+              onClick={() => onItemClick?.(item.id)}
+              onMouseEnter={() => onItemHover?.(item.id)}
+              onMouseLeave={() => onItemHover?.(null)}
+            />
+          )
+        })}
+      </svg>
+    </PaneFrame>
+  )
+}
+
+function CloseButton({ onClick }: { onClick: () => void }) {
+  return (
+    <IconButton onClick={onClick} size="small" sx={{ p: 0.5 }} aria-label="Close latent space">
+      <svg width="13" height="13" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+        <path d="M3 3l6 6M9 3l-6 6" stroke={gray[700]} strokeWidth="1.5" strokeLinecap="round" />
+      </svg>
+    </IconButton>
   )
 }
 

--- a/apps/smartem/src/components/spatial/SquareMap.tsx
+++ b/apps/smartem/src/components/spatial/SquareMap.tsx
@@ -4,6 +4,8 @@ import {
   Checkbox,
   CircularProgress,
   FormControlLabel,
+  IconButton,
+  Tooltip,
   Typography,
 } from '@mui/material'
 import { useCallback, useMemo, useState } from 'react'
@@ -68,6 +70,14 @@ interface SquareMapProps {
   predictionValues?: Record<string, Map<string, number>>
   // foilholes the system suggests collecting next; highlighted when the toggle is on
   suggestedHoleIds?: Set<string>
+  // "full" (default) fills the viewport with the micrograph and a horizontal control bar - the
+  // standalone square page. "panel" is the atlas-embedded preview (issue #68): a compact header, the
+  // micrograph fitted to its aspect ratio at the top, and the controls stacked in the space below so
+  // nothing floats and the two panes line up at the top.
+  variant?: 'full' | 'panel'
+  // Panel-only header actions; rendered as icon buttons beside the title.
+  onClose?: () => void
+  onExpand?: () => void
 }
 
 export function SquareMap({
@@ -81,6 +91,9 @@ export function SquareMap({
   predictionLayers = [],
   predictionValues = {},
   suggestedHoleIds,
+  variant = 'full',
+  onClose,
+  onExpand,
 }: SquareMapProps) {
   const [hoveredId, setHoveredId] = useState<string | null>(null)
   const [selectedId, setSelectedId] = useState<string | null>(null)
@@ -194,6 +207,309 @@ export function SquareMap({
   const vbW = imageWidth ?? 2880
   const vbH = imageHeight ?? 2046
 
+  const isPanel = variant === 'panel'
+
+  // Shared control leaves, composed differently per variant: a single horizontal bar for the full
+  // page, a stacked block under the micrograph for the embedded panel.
+  const statsItems = (
+    <>
+      <Typography variant="caption" sx={{ fontWeight: 600 }}>
+        {squareLabel}
+      </Typography>
+      <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+        {foilholes.length} foilholes
+      </Typography>
+      <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+        avg {Math.round(avgQuality * 100)}%
+      </Typography>
+      {selectionFrozen && (
+        <Typography
+          variant="caption"
+          sx={{ color: statusColors.paused, fontWeight: 500, fontSize: '0.625rem' }}
+        >
+          locked
+        </Typography>
+      )}
+    </>
+  )
+
+  const selectedHoleDetail = selectedHole ? (
+    <Box
+      sx={{
+        display: 'flex',
+        gap: 1,
+        ml: isPanel ? 0 : 0.5,
+        pl: isPanel ? 0 : 1,
+        borderLeft: isPanel ? 'none' : '1px solid',
+        borderColor: 'divider',
+      }}
+    >
+      <Typography variant="caption" sx={{ fontWeight: 500 }}>
+        {selectedHole.foilholeId}
+      </Typography>
+      <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+        {Math.round(selectedHole.quality * 100)}%
+      </Typography>
+      <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+        {selectedHole.status}
+      </Typography>
+      <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+        {selectedHole.micrographCount} mic
+      </Typography>
+      {selectedHole.isNearGridBar && (
+        <Typography variant="caption" sx={{ color: statusColors.paused, fontWeight: 500 }}>
+          near grid bar
+        </Typography>
+      )}
+    </Box>
+  ) : null
+
+  const metricSelector = (
+    <Box sx={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: 0.25 }}>
+      {BASE_METRICS.map((key) => (
+        <ButtonBase key={key} onClick={() => setMetric(key)} sx={metricButtonSx(key === metric)}>
+          {METRIC_OPTIONS[key].label.split(' ')[0]}
+        </ButtonBase>
+      ))}
+      {predictionLayers.length > 0 && (
+        <Box sx={{ width: '1px', alignSelf: 'stretch', backgroundColor: 'divider', mx: 0.25 }} />
+      )}
+      {predictionLayers.map((layer) => {
+        const key = `pred:${layer.id}`
+        return (
+          <ButtonBase key={key} onClick={() => setMetric(key)} sx={metricButtonSx(key === metric)}>
+            {layer.label}
+          </ButtonBase>
+        )
+      })}
+    </Box>
+  )
+
+  const suggestionsToggle =
+    suggestedHoleIds && suggestedHoleIds.size > 0 ? (
+      <ButtonBase
+        onClick={() => setShowSuggestions((s) => !s)}
+        sx={{
+          px: 0.75,
+          py: 0.25,
+          borderRadius: 0.5,
+          fontSize: '0.625rem',
+          fontWeight: showSuggestions ? 600 : 400,
+          color: showSuggestions ? '#2f6feb' : 'text.disabled',
+          backgroundColor: showSuggestions ? gray[50] : 'transparent',
+          '&:hover': { backgroundColor: gray[100] },
+        }}
+      >
+        Suggestions ({suggestedHoleIds.size})
+      </ButtonBase>
+    ) : null
+
+  const hideNullToggle =
+    useHeatmap || isPred ? (
+      <FormControlLabel
+        control={
+          <Checkbox
+            size="small"
+            checked={hideNull}
+            onChange={(e) => setHideNull(e.target.checked)}
+            sx={{ p: 0.25 }}
+          />
+        }
+        label={
+          <Typography variant="caption" sx={{ fontSize: '0.5625rem' }}>
+            Hide uncollected
+          </Typography>
+        }
+        sx={{ mr: 0, ml: isPanel ? 0 : 0.5 }}
+      />
+    ) : null
+
+  const legend = <HeatmapLegend useHeatmap={useHeatmap} bins={heatmapBins} />
+
+  const imageArea = (
+    <Box
+      sx={
+        isPanel
+          ? {
+              // Fill the height between header and controls as an image-viewer canvas. The landscape
+              // micrograph centres within and any leftover reads as dark matting, so the panel never
+              // ends in a white void below the controls.
+              flex: 1,
+              minHeight: 0,
+              position: 'relative',
+              overflow: 'hidden',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              backgroundColor: gray[900],
+              borderBottom: '1px solid',
+              borderColor: 'divider',
+            }
+          : {
+              flex: 1,
+              position: 'relative',
+              overflow: 'hidden',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }
+      }
+    >
+      {/* Checkered placeholder for microscope image. In the panel the area is a dark viewer canvas,
+          so drop the checker once the image is ready and let the dark matting show through. */}
+      {!(isPanel && imageReady) && (
+        <Box
+          sx={{
+            position: 'absolute',
+            inset: 0,
+            background: `repeating-conic-gradient(${gray[200]} 0% 25%, ${gray[50]} 0% 50%) 50% / 20px 20px`,
+            borderRadius: 1,
+          }}
+        />
+      )}
+      <svg
+        viewBox={`0 0 ${vbW} ${vbH}`}
+        role="img"
+        aria-label="Grid square map showing foilholes"
+        style={{
+          width: '100%',
+          height: '100%',
+          maxWidth: '100%',
+          maxHeight: '100%',
+          position: 'relative',
+          zIndex: 1,
+        }}
+        onMouseMove={(e) => {
+          const rect = e.currentTarget.getBoundingClientRect()
+          setTooltipPos({
+            x: e.clientX - rect.left,
+            y: e.clientY - rect.top,
+          })
+        }}
+      >
+        {imageUrl && (
+          <image
+            href={imageUrl}
+            x="0"
+            y="0"
+            width={vbW}
+            height={vbH}
+            preserveAspectRatio="none"
+            onLoad={() => setImageLoaded(true)}
+            onError={() => setImageLoaded(true)}
+            style={{ opacity: imageLoaded ? 1 : 0, transition: 'opacity 0.4s ease' }}
+          />
+        )}
+        <g
+          style={{
+            opacity: imageReady ? 1 : 0,
+            transition: 'opacity 0.4s ease',
+            pointerEvents: imageReady ? 'auto' : 'none',
+          }}
+        >
+          {foilholes.map((fh) => {
+            const isHovered = hoveredId === fh.uuid
+            const isSelected = selectedId === fh.uuid
+            const isNull = isNullMetric(fh)
+            const isSuggested = showSuggestions && (suggestedHoleIds?.has(fh.uuid) ?? false)
+
+            if (isNull && hideNull) return null
+
+            const fill = isNull ? 'black' : getFill(fh)
+            const opacity = isNull ? 0.2 : isHovered || isSelected ? 1.0 : 0.6
+
+            return (
+              <circle
+                key={fh.uuid}
+                role="button"
+                tabIndex={0}
+                cx={fh.xLocation}
+                cy={fh.yLocation}
+                r={fh.diameter / 2}
+                fill={fill}
+                opacity={opacity}
+                stroke={
+                  isNull
+                    ? '#cf222e'
+                    : fh.isNearGridBar
+                      ? gray[600]
+                      : isSelected
+                        ? '#e59344'
+                        : isHovered
+                          ? gray[900]
+                          : isSuggested
+                            ? '#2f6feb'
+                            : 'none'
+                }
+                strokeWidth={
+                  isNull ? 2 : fh.isNearGridBar ? 4 : isHovered || isSelected || isSuggested ? 4 : 0
+                }
+                strokeDasharray={fh.isNearGridBar ? '8 4' : 'none'}
+                strokeOpacity={isNull ? 0.4 : 1}
+                style={{ cursor: 'pointer', transition: 'opacity 0.1s' }}
+                onMouseEnter={() => handleHover(fh.uuid)}
+                onMouseLeave={() => handleHover(null)}
+                onClick={() => handleClick(fh.uuid)}
+              />
+            )
+          })}
+        </g>
+      </svg>
+
+      {/* Loading indicator while the micrograph is still being fetched/decoded */}
+      {!imageReady && (
+        <Box
+          sx={{
+            position: 'absolute',
+            inset: 0,
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 1,
+            zIndex: 2,
+            pointerEvents: 'none',
+          }}
+        >
+          <CircularProgress size={28} thickness={4} />
+          <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+            Loading image…
+          </Typography>
+        </Box>
+      )}
+
+      {/* Tooltip */}
+      {hoveredHole && (
+        <Box
+          sx={{
+            position: 'absolute',
+            left: tooltipPos.x + 12,
+            top: tooltipPos.y - 30,
+            backgroundColor: gray[900],
+            color: '#ffffff',
+            px: 1,
+            py: 0.5,
+            borderRadius: 1,
+            fontSize: '0.75rem',
+            pointerEvents: 'none',
+            whiteSpace: 'nowrap',
+            zIndex: 10,
+          }}
+        >
+          {hoveredHole.foilholeId} —{' '}
+          {isPred
+            ? hoveredValue != null
+              ? `${Math.round(hoveredValue * 100)}% predicted`
+              : 'no prediction'
+            : useHeatmap && baseMetric
+              ? `${hoveredValue ?? 'N/A'} ${METRIC_OPTIONS[baseMetric].label}`
+              : `${Math.round(hoveredHole.quality * 100)}%`}
+          {hoveredHole.isNearGridBar && ' (near grid bar)'}
+        </Box>
+      )}
+    </Box>
+  )
+
   return (
     <Box
       sx={{
@@ -203,312 +519,132 @@ export function SquareMap({
         overflow: 'hidden',
       }}
     >
-      <Box
-        sx={{
-          flex: 1,
-          position: 'relative',
-          overflow: 'hidden',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-        }}
-      >
-        {/* Checkered placeholder for microscope image */}
+      {isPanel && (
         <Box
           sx={{
-            position: 'absolute',
-            inset: 0,
-            background: `repeating-conic-gradient(${gray[200]} 0% 25%, ${gray[50]} 0% 50%) 50% / 20px 20px`,
-            borderRadius: 1,
-          }}
-        />
-        <svg
-          viewBox={`0 0 ${vbW} ${vbH}`}
-          role="img"
-          aria-label="Grid square map showing foilholes"
-          style={{
-            width: '100%',
-            height: '100%',
-            maxWidth: '100%',
-            maxHeight: '100%',
-            position: 'relative',
-            zIndex: 1,
-          }}
-          onMouseMove={(e) => {
-            const rect = e.currentTarget.getBoundingClientRect()
-            setTooltipPos({
-              x: e.clientX - rect.left,
-              y: e.clientY - rect.top,
-            })
+            display: 'flex',
+            alignItems: 'center',
+            gap: 0.5,
+            px: 1.5,
+            py: 1,
+            borderBottom: '1px solid',
+            borderColor: 'divider',
+            backgroundColor: gray[50],
+            flexShrink: 0,
           }}
         >
-          {imageUrl && (
-            <image
-              href={imageUrl}
-              x="0"
-              y="0"
-              width={vbW}
-              height={vbH}
-              preserveAspectRatio="none"
-              onLoad={() => setImageLoaded(true)}
-              onError={() => setImageLoaded(true)}
-              style={{ opacity: imageLoaded ? 1 : 0, transition: 'opacity 0.4s ease' }}
-            />
-          )}
-          <g
-            style={{
-              opacity: imageReady ? 1 : 0,
-              transition: 'opacity 0.4s ease',
-              pointerEvents: imageReady ? 'auto' : 'none',
-            }}
-          >
-            {foilholes.map((fh) => {
-              const isHovered = hoveredId === fh.uuid
-              const isSelected = selectedId === fh.uuid
-              const isNull = isNullMetric(fh)
-              const isSuggested = showSuggestions && (suggestedHoleIds?.has(fh.uuid) ?? false)
-
-              if (isNull && hideNull) return null
-
-              const fill = isNull ? 'black' : getFill(fh)
-              const opacity = isNull ? 0.2 : isHovered || isSelected ? 1.0 : 0.6
-
-              return (
-                <circle
-                  key={fh.uuid}
-                  role="button"
-                  tabIndex={0}
-                  cx={fh.xLocation}
-                  cy={fh.yLocation}
-                  r={fh.diameter / 2}
-                  fill={fill}
-                  opacity={opacity}
-                  stroke={
-                    isNull
-                      ? '#cf222e'
-                      : fh.isNearGridBar
-                        ? gray[600]
-                        : isSelected
-                          ? '#e59344'
-                          : isHovered
-                            ? gray[900]
-                            : isSuggested
-                              ? '#2f6feb'
-                              : 'none'
-                  }
-                  strokeWidth={
-                    isNull
-                      ? 2
-                      : fh.isNearGridBar
-                        ? 4
-                        : isHovered || isSelected || isSuggested
-                          ? 4
-                          : 0
-                  }
-                  strokeDasharray={fh.isNearGridBar ? '8 4' : 'none'}
-                  strokeOpacity={isNull ? 0.4 : 1}
-                  style={{ cursor: 'pointer', transition: 'opacity 0.1s' }}
-                  onMouseEnter={() => handleHover(fh.uuid)}
-                  onMouseLeave={() => handleHover(null)}
-                  onClick={() => handleClick(fh.uuid)}
-                />
-              )
-            })}
-          </g>
-        </svg>
-
-        {/* Loading indicator while the micrograph is still being fetched/decoded */}
-        {!imageReady && (
+          {/* Orange accent echoes the locked-square ring on the atlas, tying the two panes together. */}
           <Box
             sx={{
-              position: 'absolute',
-              inset: 0,
-              display: 'flex',
-              flexDirection: 'column',
-              alignItems: 'center',
-              justifyContent: 'center',
-              gap: 1,
-              zIndex: 2,
-              pointerEvents: 'none',
-            }}
-          >
-            <CircularProgress size={28} thickness={4} />
-            <Typography variant="caption" sx={{ color: 'text.secondary' }}>
-              Loading image…
-            </Typography>
-          </Box>
-        )}
-
-        {/* Tooltip */}
-        {hoveredHole && (
-          <Box
-            sx={{
-              position: 'absolute',
-              left: tooltipPos.x + 12,
-              top: tooltipPos.y - 30,
-              backgroundColor: gray[900],
-              color: '#ffffff',
-              px: 1,
-              py: 0.5,
+              width: '3px',
+              alignSelf: 'stretch',
+              minHeight: 20,
               borderRadius: 1,
-              fontSize: '0.75rem',
-              pointerEvents: 'none',
-              whiteSpace: 'nowrap',
-              zIndex: 10,
+              backgroundColor: '#e59344',
             }}
-          >
-            {hoveredHole.foilholeId} —{' '}
-            {isPred
-              ? hoveredValue != null
-                ? `${Math.round(hoveredValue * 100)}% predicted`
-                : 'no prediction'
-              : useHeatmap && baseMetric
-                ? `${hoveredValue ?? 'N/A'} ${METRIC_OPTIONS[baseMetric].label}`
-                : `${Math.round(hoveredHole.quality * 100)}%`}
-            {hoveredHole.isNearGridBar && ' (near grid bar)'}
-          </Box>
-        )}
-      </Box>
-
-      {/* Bottom controls */}
-      <Box
-        sx={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 1,
-          px: 2,
-          py: 0.75,
-          borderTop: '1px solid',
-          borderColor: 'divider',
-          flexShrink: 0,
-          flexWrap: 'wrap',
-        }}
-      >
-        <Typography variant="caption" sx={{ fontWeight: 600 }}>
-          {squareLabel}
-        </Typography>
-        <Typography variant="caption" sx={{ color: 'text.secondary' }}>
-          {foilholes.length} foilholes
-        </Typography>
-        <Typography variant="caption" sx={{ color: 'text.secondary' }}>
-          avg {Math.round(avgQuality * 100)}%
-        </Typography>
-
-        {selectionFrozen && (
-          <Typography
-            variant="caption"
-            sx={{
-              color: statusColors.paused,
-              fontWeight: 500,
-              fontSize: '0.625rem',
-            }}
-          >
-            locked
-          </Typography>
-        )}
-
-        {selectedHole && (
-          <Box
-            sx={{
-              display: 'flex',
-              gap: 1,
-              ml: 0.5,
-              pl: 1,
-              borderLeft: '1px solid',
-              borderColor: 'divider',
-            }}
-          >
-            <Typography variant="caption" sx={{ fontWeight: 500 }}>
-              {selectedHole.foilholeId}
-            </Typography>
-            <Typography variant="caption" sx={{ color: 'text.secondary' }}>
-              {Math.round(selectedHole.quality * 100)}%
-            </Typography>
-            <Typography variant="caption" sx={{ color: 'text.secondary' }}>
-              {selectedHole.status}
-            </Typography>
-            <Typography variant="caption" sx={{ color: 'text.secondary' }}>
-              {selectedHole.micrographCount} mic
-            </Typography>
-            {selectedHole.isNearGridBar && (
-              <Typography variant="caption" sx={{ color: statusColors.paused, fontWeight: 500 }}>
-                near grid bar
-              </Typography>
-            )}
-          </Box>
-        )}
-
-        <Box sx={{ flex: 1 }} />
-
-        {/* Metric / prediction-layer selector */}
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.25 }}>
-          {BASE_METRICS.map((key) => (
-            <ButtonBase
-              key={key}
-              onClick={() => setMetric(key)}
-              sx={metricButtonSx(key === metric)}
-            >
-              {METRIC_OPTIONS[key].label.split(' ')[0]}
-            </ButtonBase>
-          ))}
-          {predictionLayers.length > 0 && (
-            <Box
-              sx={{ width: '1px', alignSelf: 'stretch', backgroundColor: 'divider', mx: 0.25 }}
-            />
-          )}
-          {predictionLayers.map((layer) => {
-            const key = `pred:${layer.id}`
-            return (
-              <ButtonBase
-                key={key}
-                onClick={() => setMetric(key)}
-                sx={metricButtonSx(key === metric)}
-              >
-                {layer.label}
-              </ButtonBase>
-            )
-          })}
-        </Box>
-
-        {suggestedHoleIds && suggestedHoleIds.size > 0 && (
-          <ButtonBase
-            onClick={() => setShowSuggestions((s) => !s)}
-            sx={{
-              px: 0.75,
-              py: 0.25,
-              borderRadius: 0.5,
-              fontSize: '0.625rem',
-              fontWeight: showSuggestions ? 600 : 400,
-              color: showSuggestions ? '#2f6feb' : 'text.disabled',
-              backgroundColor: showSuggestions ? gray[50] : 'transparent',
-              '&:hover': { backgroundColor: gray[100] },
-            }}
-          >
-            Suggestions ({suggestedHoleIds.size})
-          </ButtonBase>
-        )}
-
-        {(useHeatmap || isPred) && (
-          <FormControlLabel
-            control={
-              <Checkbox
-                size="small"
-                checked={hideNull}
-                onChange={(e) => setHideNull(e.target.checked)}
-                sx={{ p: 0.25 }}
-              />
-            }
-            label={
-              <Typography variant="caption" sx={{ fontSize: '0.5625rem' }}>
-                Hide uncollected
-              </Typography>
-            }
-            sx={{ mr: 0, ml: 0.5 }}
           />
-        )}
+          <Box sx={{ minWidth: 0, flex: 1 }}>
+            <Typography
+              variant="caption"
+              noWrap
+              sx={{ fontWeight: 700, display: 'block', lineHeight: 1.25 }}
+            >
+              {squareLabel}
+            </Typography>
+            <Typography variant="caption" sx={{ color: 'text.secondary', fontSize: '0.625rem' }}>
+              {foilholes.length} foilholes · avg {Math.round(avgQuality * 100)}%
+              {selectionFrozen ? ' · locked' : ''}
+            </Typography>
+          </Box>
+          {onExpand && (
+            <Tooltip title="Open full square view" placement="bottom">
+              <IconButton
+                onClick={onExpand}
+                size="small"
+                sx={{ p: 0.5 }}
+                aria-label="Open full square view"
+              >
+                <svg width="13" height="13" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                  <path
+                    d="M6 3h7v7M13 3l-7 7M11 9v4H3V5h4"
+                    stroke={gray[700]}
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              </IconButton>
+            </Tooltip>
+          )}
+          {onClose && (
+            <Tooltip title="Close grid square" placement="bottom">
+              <IconButton
+                onClick={onClose}
+                size="small"
+                sx={{ p: 0.5 }}
+                aria-label="Close grid square panel"
+              >
+                <svg width="13" height="13" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+                  <path
+                    d="M3 3l6 6M9 3l-6 6"
+                    stroke={gray[700]}
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                  />
+                </svg>
+              </IconButton>
+            </Tooltip>
+          )}
+        </Box>
+      )}
 
-        <HeatmapLegend useHeatmap={useHeatmap} bins={heatmapBins} />
-      </Box>
+      {imageArea}
+
+      {isPanel ? (
+        // Controls pinned directly below the viewer canvas at their natural height (the image area
+        // above takes the slack), so there is no empty band at the foot of the panel.
+        <Box
+          sx={{
+            flexShrink: 0,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 1,
+            px: 1.5,
+            py: 1.25,
+          }}
+        >
+          {selectedHoleDetail}
+          {metricSelector}
+          <Box sx={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: 1 }}>
+            {suggestionsToggle}
+            {hideNullToggle}
+            <Box sx={{ flex: 1 }} />
+            {legend}
+          </Box>
+        </Box>
+      ) : (
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1,
+            px: 2,
+            py: 0.75,
+            borderTop: '1px solid',
+            borderColor: 'divider',
+            flexShrink: 0,
+            flexWrap: 'wrap',
+          }}
+        >
+          {statsItems}
+          {selectedHoleDetail}
+          <Box sx={{ flex: 1 }} />
+          {metricSelector}
+          {suggestionsToggle}
+          {hideNullToggle}
+          {legend}
+        </Box>
+      )}
     </Box>
   )
 }

--- a/apps/smartem/src/components/spatial/SquareMap.tsx
+++ b/apps/smartem/src/components/spatial/SquareMap.tsx
@@ -18,6 +18,7 @@ import {
   qualityColor,
   valueToHeatmapColor,
 } from '~/utils/heatmap'
+import { SPATIAL_FOOTER_MIN_HEIGHT } from './layout'
 
 type BaseMetric = 'quality' | 'resolution' | 'astigmatism' | 'particleCount'
 
@@ -601,16 +602,19 @@ export function SquareMap({
       {imageArea}
 
       {isPanel ? (
-        // Controls pinned directly below the viewer canvas at their natural height (the image area
-        // above takes the slack), so there is no empty band at the foot of the panel.
+        // Controls pinned directly below the viewer canvas (the image area above takes the slack), so
+        // there is no empty band at the foot of the panel. Shares its height floor with the atlas footer
+        // so the two footers line up; the stacked controls centre within it.
         <Box
           sx={{
             flexShrink: 0,
             display: 'flex',
             flexDirection: 'column',
+            justifyContent: 'center',
             gap: 1,
             px: 1.5,
             py: 1.25,
+            minHeight: SPATIAL_FOOTER_MIN_HEIGHT,
           }}
         >
           {selectedHoleDetail}

--- a/apps/smartem/src/components/spatial/SquareMap.tsx
+++ b/apps/smartem/src/components/spatial/SquareMap.tsx
@@ -5,6 +5,8 @@ import {
   CircularProgress,
   FormControlLabel,
   IconButton,
+  MenuItem,
+  Select,
   Tooltip,
   Typography,
 } from '@mui/material'
@@ -210,6 +212,19 @@ export function SquareMap({
 
   const isPanel = variant === 'panel'
 
+  // Panel header subtitle: the square summary by default, swapping to the selected foilhole's detail
+  // when one is picked. Keeping that (variable-length) detail in the fixed-height header rather than the
+  // footer means the footer stays at a constant height aligned with the atlas footer.
+  const panelSubtitle = selectedHole
+    ? [
+        selectedHole.foilholeId,
+        `${Math.round(selectedHole.quality * 100)}%`,
+        selectedHole.status,
+        `${selectedHole.micrographCount} mic`,
+        ...(selectedHole.isNearGridBar ? ['near grid bar'] : []),
+      ].join(' · ')
+    : `${foilholes.length} foilholes · avg ${Math.round(avgQuality * 100)}%${selectionFrozen ? ' · locked' : ''}`
+
   // Shared control leaves, composed differently per variant: a single horizontal bar for the full
   // page, a stacked block under the micrograph for the embedded panel.
   const statsItems = (
@@ -273,16 +288,34 @@ export function SquareMap({
         </ButtonBase>
       ))}
       {predictionLayers.length > 0 && (
-        <Box sx={{ width: '1px', alignSelf: 'stretch', backgroundColor: 'divider', mx: 0.25 }} />
+        <>
+          <Box sx={{ width: '1px', alignSelf: 'stretch', backgroundColor: 'divider', mx: 0.25 }} />
+          <Select
+            size="small"
+            variant="standard"
+            displayEmpty
+            value={isPred ? (predLayerId ?? '') : ''}
+            onChange={(e) => {
+              if (e.target.value) setMetric(`pred:${e.target.value}`)
+            }}
+            renderValue={(value) =>
+              value ? (predictionLayers.find((l) => l.id === value)?.label ?? value) : 'Predictions'
+            }
+            sx={{
+              fontSize: '0.5625rem',
+              maxWidth: 180,
+              color: isPred ? 'text.primary' : 'text.disabled',
+              '& .MuiSelect-select': { py: 0.25, pr: 2.5 },
+            }}
+          >
+            {predictionLayers.map((layer) => (
+              <MenuItem key={layer.id} value={layer.id} sx={{ fontSize: '0.75rem' }}>
+                {layer.label}
+              </MenuItem>
+            ))}
+          </Select>
+        </>
       )}
-      {predictionLayers.map((layer) => {
-        const key = `pred:${layer.id}`
-        return (
-          <ButtonBase key={key} onClick={() => setMetric(key)} sx={metricButtonSx(key === metric)}>
-            {layer.label}
-          </ButtonBase>
-        )
-      })}
     </Box>
   )
 
@@ -492,10 +525,7 @@ export function SquareMap({
     return (
       <PaneFrame
         title={squareLabel}
-        subtitle={`${foilholes.length} foilholes · avg ${Math.round(avgQuality * 100)}%${
-          selectionFrozen ? ' · locked' : ''
-        }`}
-        accentColor="#e59344"
+        subtitle={panelSubtitle}
         bodyBackground={gray[900]}
         actions={
           <>
@@ -541,8 +571,7 @@ export function SquareMap({
           </>
         }
         footer={
-          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, px: 1.5, py: 1.25 }}>
-            {selectedHoleDetail}
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, px: 1.5, py: 1 }}>
             {metricSelector}
             <Box sx={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: 1 }}>
               {suggestionsToggle}

--- a/apps/smartem/src/components/spatial/SquareMap.tsx
+++ b/apps/smartem/src/components/spatial/SquareMap.tsx
@@ -9,6 +9,7 @@ import {
   Typography,
 } from '@mui/material'
 import { useCallback, useMemo, useState } from 'react'
+import { PaneFrame } from '~/components/layout/PaneFrame'
 import type { MockFoilHole } from '~/data/mock-session-detail'
 import { gray, statusColors } from '~/theme'
 import {
@@ -18,7 +19,6 @@ import {
   qualityColor,
   valueToHeatmapColor,
 } from '~/utils/heatmap'
-import { SPATIAL_FOOTER_MIN_HEIGHT } from './layout'
 
 type BaseMetric = 'quality' | 'resolution' | 'astigmatism' | 'particleCount'
 
@@ -327,35 +327,10 @@ export function SquareMap({
 
   const legend = <HeatmapLegend useHeatmap={useHeatmap} bins={heatmapBins} />
 
-  const imageArea = (
-    <Box
-      sx={
-        isPanel
-          ? {
-              // Fill the height between header and controls as an image-viewer canvas. The landscape
-              // micrograph centres within and any leftover reads as dark matting, so the panel never
-              // ends in a white void below the controls.
-              flex: 1,
-              minHeight: 0,
-              position: 'relative',
-              overflow: 'hidden',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              backgroundColor: gray[900],
-              borderBottom: '1px solid',
-              borderColor: 'divider',
-            }
-          : {
-              flex: 1,
-              position: 'relative',
-              overflow: 'hidden',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-            }
-      }
-    >
+  // Inner content of the image canvas (placeholder + svg overlay + loading + tooltip), shared by both
+  // variants: the panel wraps it in a PaneFrame body, the full page in its own canvas Box.
+  const mapContent = (
+    <>
       {/* Checkered placeholder for microscope image. In the panel the area is a dark viewer canvas,
           so drop the checker once the image is ready and let the dark matting show through. */}
       {!(isPanel && imageReady) && (
@@ -508,9 +483,82 @@ export function SquareMap({
           {hoveredHole.isNearGridBar && ' (near grid bar)'}
         </Box>
       )}
-    </Box>
+    </>
   )
 
+  // Embedded preview (issue #68): compose the shared PaneFrame so the header and footer line up with the
+  // atlas pane structurally. The orange accent echoes the locked-square ring tying the two panes together.
+  if (isPanel) {
+    return (
+      <PaneFrame
+        title={squareLabel}
+        subtitle={`${foilholes.length} foilholes · avg ${Math.round(avgQuality * 100)}%${
+          selectionFrozen ? ' · locked' : ''
+        }`}
+        accentColor="#e59344"
+        bodyBackground={gray[900]}
+        actions={
+          <>
+            {onExpand && (
+              <Tooltip title="Open full square view" placement="bottom">
+                <IconButton
+                  onClick={onExpand}
+                  size="small"
+                  sx={{ p: 0.5 }}
+                  aria-label="Open full square view"
+                >
+                  <svg width="13" height="13" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                    <path
+                      d="M6 3h7v7M13 3l-7 7M11 9v4H3V5h4"
+                      stroke={gray[700]}
+                      strokeWidth="1.5"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                  </svg>
+                </IconButton>
+              </Tooltip>
+            )}
+            {onClose && (
+              <Tooltip title="Close grid square" placement="bottom">
+                <IconButton
+                  onClick={onClose}
+                  size="small"
+                  sx={{ p: 0.5 }}
+                  aria-label="Close grid square panel"
+                >
+                  <svg width="13" height="13" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+                    <path
+                      d="M3 3l6 6M9 3l-6 6"
+                      stroke={gray[700]}
+                      strokeWidth="1.5"
+                      strokeLinecap="round"
+                    />
+                  </svg>
+                </IconButton>
+              </Tooltip>
+            )}
+          </>
+        }
+        footer={
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, px: 1.5, py: 1.25 }}>
+            {selectedHoleDetail}
+            {metricSelector}
+            <Box sx={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: 1 }}>
+              {suggestionsToggle}
+              {hideNullToggle}
+              <Box sx={{ flex: 1 }} />
+              {legend}
+            </Box>
+          </Box>
+        }
+      >
+        {mapContent}
+      </PaneFrame>
+    )
+  }
+
+  // Full-page square view: micrograph canvas plus a single horizontal control bar.
   return (
     <Box
       sx={{
@@ -520,135 +568,39 @@ export function SquareMap({
         overflow: 'hidden',
       }}
     >
-      {isPanel && (
-        <Box
-          sx={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 0.5,
-            px: 1.5,
-            py: 1,
-            borderBottom: '1px solid',
-            borderColor: 'divider',
-            backgroundColor: gray[50],
-            flexShrink: 0,
-          }}
-        >
-          {/* Orange accent echoes the locked-square ring on the atlas, tying the two panes together. */}
-          <Box
-            sx={{
-              width: '3px',
-              alignSelf: 'stretch',
-              minHeight: 20,
-              borderRadius: 1,
-              backgroundColor: '#e59344',
-            }}
-          />
-          <Box sx={{ minWidth: 0, flex: 1 }}>
-            <Typography
-              variant="caption"
-              noWrap
-              sx={{ fontWeight: 700, display: 'block', lineHeight: 1.25 }}
-            >
-              {squareLabel}
-            </Typography>
-            <Typography variant="caption" sx={{ color: 'text.secondary', fontSize: '0.625rem' }}>
-              {foilholes.length} foilholes · avg {Math.round(avgQuality * 100)}%
-              {selectionFrozen ? ' · locked' : ''}
-            </Typography>
-          </Box>
-          {onExpand && (
-            <Tooltip title="Open full square view" placement="bottom">
-              <IconButton
-                onClick={onExpand}
-                size="small"
-                sx={{ p: 0.5 }}
-                aria-label="Open full square view"
-              >
-                <svg width="13" height="13" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-                  <path
-                    d="M6 3h7v7M13 3l-7 7M11 9v4H3V5h4"
-                    stroke={gray[700]}
-                    strokeWidth="1.5"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                </svg>
-              </IconButton>
-            </Tooltip>
-          )}
-          {onClose && (
-            <Tooltip title="Close grid square" placement="bottom">
-              <IconButton
-                onClick={onClose}
-                size="small"
-                sx={{ p: 0.5 }}
-                aria-label="Close grid square panel"
-              >
-                <svg width="13" height="13" viewBox="0 0 12 12" fill="none" aria-hidden="true">
-                  <path
-                    d="M3 3l6 6M9 3l-6 6"
-                    stroke={gray[700]}
-                    strokeWidth="1.5"
-                    strokeLinecap="round"
-                  />
-                </svg>
-              </IconButton>
-            </Tooltip>
-          )}
-        </Box>
-      )}
-
-      {imageArea}
-
-      {isPanel ? (
-        // Controls pinned directly below the viewer canvas (the image area above takes the slack), so
-        // there is no empty band at the foot of the panel. Shares its height floor with the atlas footer
-        // so the two footers line up; the stacked controls centre within it.
-        <Box
-          sx={{
-            flexShrink: 0,
-            display: 'flex',
-            flexDirection: 'column',
-            justifyContent: 'center',
-            gap: 1,
-            px: 1.5,
-            py: 1.25,
-            minHeight: SPATIAL_FOOTER_MIN_HEIGHT,
-          }}
-        >
-          {selectedHoleDetail}
-          {metricSelector}
-          <Box sx={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: 1 }}>
-            {suggestionsToggle}
-            {hideNullToggle}
-            <Box sx={{ flex: 1 }} />
-            {legend}
-          </Box>
-        </Box>
-      ) : (
-        <Box
-          sx={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 1,
-            px: 2,
-            py: 0.75,
-            borderTop: '1px solid',
-            borderColor: 'divider',
-            flexShrink: 0,
-            flexWrap: 'wrap',
-          }}
-        >
-          {statsItems}
-          {selectedHoleDetail}
-          <Box sx={{ flex: 1 }} />
-          {metricSelector}
-          {suggestionsToggle}
-          {hideNullToggle}
-          {legend}
-        </Box>
-      )}
+      <Box
+        sx={{
+          flex: 1,
+          position: 'relative',
+          overflow: 'hidden',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        {mapContent}
+      </Box>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1,
+          px: 2,
+          py: 0.75,
+          borderTop: '1px solid',
+          borderColor: 'divider',
+          flexShrink: 0,
+          flexWrap: 'wrap',
+        }}
+      >
+        {statsItems}
+        {selectedHoleDetail}
+        <Box sx={{ flex: 1 }} />
+        {metricSelector}
+        {suggestionsToggle}
+        {hideNullToggle}
+        {legend}
+      </Box>
     </Box>
   )
 }

--- a/apps/smartem/src/components/spatial/SquareMap.tsx
+++ b/apps/smartem/src/components/spatial/SquareMap.tsx
@@ -58,6 +58,10 @@ interface SquareMapProps {
   squareLabel: string
   imageUrl?: string
   imageLoading?: boolean
+  // Natural pixel size of the micrograph. Foilhole coords are in this space, so the viewBox must
+  // match it; falls back to the standard gridsquare image size until the image has decoded.
+  imageWidth?: number
+  imageHeight?: number
   onFoilholeClick?: (uuid: string) => void
   predictionLayers?: PredictionLayer[]
   // layer id -> (foilhole uuid -> predicted value, 0..1)
@@ -71,6 +75,8 @@ export function SquareMap({
   squareLabel,
   imageUrl,
   imageLoading,
+  imageWidth,
+  imageHeight,
   onFoilholeClick,
   predictionLayers = [],
   predictionValues = {},
@@ -183,6 +189,11 @@ export function SquareMap({
   const avgQuality =
     foilholes.length > 0 ? foilholes.reduce((sum, h) => sum + h.quality, 0) / foilholes.length : 0
 
+  // Foilhole coords live in the micrograph's native pixel space; match the viewBox to it (falling
+  // back to the standard gridsquare size until the image decodes) so the overlay stays on the image.
+  const vbW = imageWidth ?? 2880
+  const vbH = imageHeight ?? 2046
+
   return (
     <Box
       sx={{
@@ -212,7 +223,7 @@ export function SquareMap({
           }}
         />
         <svg
-          viewBox="0 0 2880 2046"
+          viewBox={`0 0 ${vbW} ${vbH}`}
           role="img"
           aria-label="Grid square map showing foilholes"
           style={{
@@ -236,8 +247,8 @@ export function SquareMap({
               href={imageUrl}
               x="0"
               y="0"
-              width="2880"
-              height="2046"
+              width={vbW}
+              height={vbH}
               preserveAspectRatio="none"
               onLoad={() => setImageLoaded(true)}
               onError={() => setImageLoaded(true)}

--- a/apps/smartem/src/components/spatial/SquarePreviewPanel.tsx
+++ b/apps/smartem/src/components/spatial/SquarePreviewPanel.tsx
@@ -1,7 +1,5 @@
-import { Box, IconButton, Tooltip } from '@mui/material'
 import { useNavigate } from '@tanstack/react-router'
 import { useSquareMapData } from '~/hooks/useSquareMapData'
-import { gray } from '~/theme'
 import { SquareMap } from './SquareMap'
 
 interface SquarePreviewPanelProps {
@@ -12,11 +10,10 @@ interface SquarePreviewPanelProps {
 }
 
 // The atlas-embedded grid-square preview (issue #68): clicking a square on the atlas locks it and
-// fills this panel with the same SquareMap the full-page view uses, so the square sits alongside
-// the atlas. The micrograph only loads while this panel is mounted (i.e. on an explicit click),
-// never on hover - see the load-on-commit note on #68. Framed to match the atlas (image fills the
-// panel + a bottom control bar); the controls float top-right so both image areas line up at the
-// top.
+// fills this panel with the same SquareMap the full-page view uses, rendered in its "panel" variant -
+// a header, the micrograph fitted to its aspect ratio at the top (aligned with the atlas), and the
+// controls in the space below. The micrograph only loads while this panel is mounted (i.e. on an
+// explicit click), never on hover - see the load-on-commit note on #68.
 export function SquarePreviewPanel({
   acquisitionId,
   gridId,
@@ -37,75 +34,30 @@ export function SquarePreviewPanel({
   } = useSquareMapData(squareId)
 
   return (
-    <Box sx={{ position: 'relative', height: '100%', overflow: 'hidden' }}>
-      <SquareMap
-        foilholes={foilholes}
-        squareLabel={squareLabel}
-        imageUrl={imageUrl}
-        imageLoading={imageLoading}
-        imageWidth={imageWidth}
-        imageHeight={imageHeight}
-        predictionLayers={predictionLayers}
-        predictionValues={predictionValues}
-        suggestedHoleIds={suggestedHoleIds}
-        onFoilholeClick={(holeUuid) => {
-          navigate({
-            to: '/acquisitions/$acquisitionId/grids/$gridId/squares/$squareId/holes/$holeId',
-            params: { acquisitionId, gridId, squareId, holeId: holeUuid },
-          })
-        }}
-      />
-
-      <Box sx={{ position: 'absolute', top: 8, right: 8, zIndex: 5, display: 'flex', gap: 0.5 }}>
-        <Tooltip title="Open full square view" placement="bottom">
-          <IconButton
-            onClick={() =>
-              navigate({
-                to: '/acquisitions/$acquisitionId/grids/$gridId/squares/$squareId',
-                params: { acquisitionId, gridId, squareId },
-              })
-            }
-            size="small"
-            sx={floatingButtonSx}
-            aria-label="Open full square view"
-          >
-            <svg width="13" height="13" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-              <path
-                d="M6 3h7v7M13 3l-7 7M11 9v4H3V5h4"
-                stroke={gray[700]}
-                strokeWidth="1.5"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-            </svg>
-          </IconButton>
-        </Tooltip>
-        <Tooltip title="Close grid square" placement="bottom">
-          <IconButton
-            onClick={onClose}
-            size="small"
-            sx={floatingButtonSx}
-            aria-label="Close grid square panel"
-          >
-            <svg width="13" height="13" viewBox="0 0 12 12" fill="none" aria-hidden="true">
-              <path
-                d="M3 3l6 6M9 3l-6 6"
-                stroke={gray[700]}
-                strokeWidth="1.5"
-                strokeLinecap="round"
-              />
-            </svg>
-          </IconButton>
-        </Tooltip>
-      </Box>
-    </Box>
+    <SquareMap
+      variant="panel"
+      foilholes={foilholes}
+      squareLabel={squareLabel}
+      imageUrl={imageUrl}
+      imageLoading={imageLoading}
+      imageWidth={imageWidth}
+      imageHeight={imageHeight}
+      predictionLayers={predictionLayers}
+      predictionValues={predictionValues}
+      suggestedHoleIds={suggestedHoleIds}
+      onClose={onClose}
+      onExpand={() =>
+        navigate({
+          to: '/acquisitions/$acquisitionId/grids/$gridId/squares/$squareId',
+          params: { acquisitionId, gridId, squareId },
+        })
+      }
+      onFoilholeClick={(holeUuid) => {
+        navigate({
+          to: '/acquisitions/$acquisitionId/grids/$gridId/squares/$squareId/holes/$holeId',
+          params: { acquisitionId, gridId, squareId, holeId: holeUuid },
+        })
+      }}
+    />
   )
 }
-
-const floatingButtonSx = {
-  p: 0.5,
-  backgroundColor: '#ffffff',
-  border: '1px solid',
-  borderColor: 'divider',
-  '&:hover': { backgroundColor: gray[100] },
-} as const

--- a/apps/smartem/src/components/spatial/SquarePreviewPanel.tsx
+++ b/apps/smartem/src/components/spatial/SquarePreviewPanel.tsx
@@ -1,4 +1,4 @@
-import { Box, IconButton, Tooltip, Typography } from '@mui/material'
+import { Box, IconButton, Tooltip } from '@mui/material'
 import { useNavigate } from '@tanstack/react-router'
 import { useSquareMapData } from '~/hooks/useSquareMapData'
 import { gray } from '~/theme'
@@ -14,7 +14,9 @@ interface SquarePreviewPanelProps {
 // The atlas-embedded grid-square preview (issue #68): clicking a square on the atlas locks it and
 // fills this panel with the same SquareMap the full-page view uses, so the square sits alongside
 // the atlas. The micrograph only loads while this panel is mounted (i.e. on an explicit click),
-// never on hover - see the load-on-commit note on #68.
+// never on hover - see the load-on-commit note on #68. Framed to match the atlas (image fills the
+// panel + a bottom control bar); the controls float top-right so both image areas line up at the
+// top.
 export function SquarePreviewPanel({
   acquisitionId,
   gridId,
@@ -27,37 +29,34 @@ export function SquarePreviewPanel({
     squareLabel,
     imageUrl,
     imageLoading,
+    imageWidth,
+    imageHeight,
     predictionLayers,
     predictionValues,
     suggestedHoleIds,
   } = useSquareMapData(squareId)
 
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden' }}>
-      <Box
-        sx={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 1,
-          px: 1.5,
-          height: 28,
-          backgroundColor: gray[100],
-          borderBottom: '1px solid',
-          borderColor: 'divider',
-          flexShrink: 0,
+    <Box sx={{ position: 'relative', height: '100%', overflow: 'hidden' }}>
+      <SquareMap
+        foilholes={foilholes}
+        squareLabel={squareLabel}
+        imageUrl={imageUrl}
+        imageLoading={imageLoading}
+        imageWidth={imageWidth}
+        imageHeight={imageHeight}
+        predictionLayers={predictionLayers}
+        predictionValues={predictionValues}
+        suggestedHoleIds={suggestedHoleIds}
+        onFoilholeClick={(holeUuid) => {
+          navigate({
+            to: '/acquisitions/$acquisitionId/grids/$gridId/squares/$squareId/holes/$holeId',
+            params: { acquisitionId, gridId, squareId, holeId: holeUuid },
+          })
         }}
-      >
-        <Typography variant="caption" sx={{ fontWeight: 600, fontSize: '0.6875rem' }}>
-          Grid Square
-        </Typography>
-        <Typography
-          variant="caption"
-          sx={{ color: 'text.secondary', fontSize: '0.6875rem', minWidth: 0 }}
-          noWrap
-        >
-          {squareLabel}
-        </Typography>
-        <Box sx={{ flex: 1 }} />
+      />
+
+      <Box sx={{ position: 'absolute', top: 8, right: 8, zIndex: 5, display: 'flex', gap: 0.5 }}>
         <Tooltip title="Open full square view" placement="bottom">
           <IconButton
             onClick={() =>
@@ -67,13 +66,13 @@ export function SquarePreviewPanel({
               })
             }
             size="small"
-            sx={{ p: 0.25 }}
+            sx={floatingButtonSx}
             aria-label="Open full square view"
           >
             <svg width="13" height="13" viewBox="0 0 16 16" fill="none" aria-hidden="true">
               <path
                 d="M6 3h7v7M13 3l-7 7M11 9v4H3V5h4"
-                stroke={gray[600]}
+                stroke={gray[700]}
                 strokeWidth="1.5"
                 strokeLinecap="round"
                 strokeLinejoin="round"
@@ -81,40 +80,32 @@ export function SquarePreviewPanel({
             </svg>
           </IconButton>
         </Tooltip>
-        <CloseButton onClick={onClose} />
-      </Box>
-      <Box sx={{ flex: 1, overflow: 'hidden' }}>
-        <SquareMap
-          foilholes={foilholes}
-          squareLabel={squareLabel}
-          imageUrl={imageUrl}
-          imageLoading={imageLoading}
-          predictionLayers={predictionLayers}
-          predictionValues={predictionValues}
-          suggestedHoleIds={suggestedHoleIds}
-          onFoilholeClick={(holeUuid) => {
-            navigate({
-              to: '/acquisitions/$acquisitionId/grids/$gridId/squares/$squareId/holes/$holeId',
-              params: { acquisitionId, gridId, squareId, holeId: holeUuid },
-            })
-          }}
-        />
+        <Tooltip title="Close grid square" placement="bottom">
+          <IconButton
+            onClick={onClose}
+            size="small"
+            sx={floatingButtonSx}
+            aria-label="Close grid square panel"
+          >
+            <svg width="13" height="13" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+              <path
+                d="M3 3l6 6M9 3l-6 6"
+                stroke={gray[700]}
+                strokeWidth="1.5"
+                strokeLinecap="round"
+              />
+            </svg>
+          </IconButton>
+        </Tooltip>
       </Box>
     </Box>
   )
 }
 
-function CloseButton({ onClick }: { onClick: () => void }) {
-  return (
-    <IconButton
-      onClick={onClick}
-      size="small"
-      sx={{ p: 0.25 }}
-      aria-label="Close grid square panel"
-    >
-      <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
-        <path d="M3 3l6 6M9 3l-6 6" stroke={gray[600]} strokeWidth="1.5" strokeLinecap="round" />
-      </svg>
-    </IconButton>
-  )
-}
+const floatingButtonSx = {
+  p: 0.5,
+  backgroundColor: '#ffffff',
+  border: '1px solid',
+  borderColor: 'divider',
+  '&:hover': { backgroundColor: gray[100] },
+} as const

--- a/apps/smartem/src/components/spatial/SquarePreviewPanel.tsx
+++ b/apps/smartem/src/components/spatial/SquarePreviewPanel.tsx
@@ -1,0 +1,120 @@
+import { Box, IconButton, Tooltip, Typography } from '@mui/material'
+import { useNavigate } from '@tanstack/react-router'
+import { useSquareMapData } from '~/hooks/useSquareMapData'
+import { gray } from '~/theme'
+import { SquareMap } from './SquareMap'
+
+interface SquarePreviewPanelProps {
+  acquisitionId: string
+  gridId: string
+  squareId: string
+  onClose: () => void
+}
+
+// The atlas-embedded grid-square preview (issue #68): clicking a square on the atlas locks it and
+// fills this panel with the same SquareMap the full-page view uses, so the square sits alongside
+// the atlas. The micrograph only loads while this panel is mounted (i.e. on an explicit click),
+// never on hover - see the load-on-commit note on #68.
+export function SquarePreviewPanel({
+  acquisitionId,
+  gridId,
+  squareId,
+  onClose,
+}: SquarePreviewPanelProps) {
+  const navigate = useNavigate()
+  const {
+    foilholes,
+    squareLabel,
+    imageUrl,
+    imageLoading,
+    predictionLayers,
+    predictionValues,
+    suggestedHoleIds,
+  } = useSquareMapData(squareId)
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden' }}>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1,
+          px: 1.5,
+          height: 28,
+          backgroundColor: gray[100],
+          borderBottom: '1px solid',
+          borderColor: 'divider',
+          flexShrink: 0,
+        }}
+      >
+        <Typography variant="caption" sx={{ fontWeight: 600, fontSize: '0.6875rem' }}>
+          Grid Square
+        </Typography>
+        <Typography
+          variant="caption"
+          sx={{ color: 'text.secondary', fontSize: '0.6875rem', minWidth: 0 }}
+          noWrap
+        >
+          {squareLabel}
+        </Typography>
+        <Box sx={{ flex: 1 }} />
+        <Tooltip title="Open full square view" placement="bottom">
+          <IconButton
+            onClick={() =>
+              navigate({
+                to: '/acquisitions/$acquisitionId/grids/$gridId/squares/$squareId',
+                params: { acquisitionId, gridId, squareId },
+              })
+            }
+            size="small"
+            sx={{ p: 0.25 }}
+            aria-label="Open full square view"
+          >
+            <svg width="13" height="13" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+              <path
+                d="M6 3h7v7M13 3l-7 7M11 9v4H3V5h4"
+                stroke={gray[600]}
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </IconButton>
+        </Tooltip>
+        <CloseButton onClick={onClose} />
+      </Box>
+      <Box sx={{ flex: 1, overflow: 'hidden' }}>
+        <SquareMap
+          foilholes={foilholes}
+          squareLabel={squareLabel}
+          imageUrl={imageUrl}
+          imageLoading={imageLoading}
+          predictionLayers={predictionLayers}
+          predictionValues={predictionValues}
+          suggestedHoleIds={suggestedHoleIds}
+          onFoilholeClick={(holeUuid) => {
+            navigate({
+              to: '/acquisitions/$acquisitionId/grids/$gridId/squares/$squareId/holes/$holeId',
+              params: { acquisitionId, gridId, squareId, holeId: holeUuid },
+            })
+          }}
+        />
+      </Box>
+    </Box>
+  )
+}
+
+function CloseButton({ onClick }: { onClick: () => void }) {
+  return (
+    <IconButton
+      onClick={onClick}
+      size="small"
+      sx={{ p: 0.25 }}
+      aria-label="Close grid square panel"
+    >
+      <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+        <path d="M3 3l6 6M9 3l-6 6" stroke={gray[600]} strokeWidth="1.5" strokeLinecap="round" />
+      </svg>
+    </IconButton>
+  )
+}

--- a/apps/smartem/src/components/spatial/layout.ts
+++ b/apps/smartem/src/components/spatial/layout.ts
@@ -1,0 +1,7 @@
+// Shared layout constants for the side-by-side spatial panes (atlas + grid-square panel).
+
+// Both panes share this footer height so their control bars line up exactly, mirroring the matched
+// header bars - together the two panes read as one symmetric split. The grid-square panel's footer
+// (metric selector row + toggles/legend row) is the taller of the two and sets the floor; the atlas
+// footer, a single row, pads up to it and centres its content.
+export const SPATIAL_FOOTER_MIN_HEIGHT = 60

--- a/apps/smartem/src/components/spatial/layout.ts
+++ b/apps/smartem/src/components/spatial/layout.ts
@@ -1,7 +1,0 @@
-// Shared layout constants for the side-by-side spatial panes (atlas + grid-square panel).
-
-// Both panes share this footer height so their control bars line up exactly, mirroring the matched
-// header bars - together the two panes read as one symmetric split. The grid-square panel's footer
-// (metric selector row + toggles/legend row) is the taller of the two and sets the floor; the atlas
-// footer, a single row, pads up to it and centres its content.
-export const SPATIAL_FOOTER_MIN_HEIGHT = 60

--- a/apps/smartem/src/components/weights/WeightsMatrix.tsx
+++ b/apps/smartem/src/components/weights/WeightsMatrix.tsx
@@ -239,12 +239,20 @@ export function WeightsMatrix({ weightsByModel, showTimeSlider = false }: Props)
                 borderColor: 'divider',
               }}
             >
-              <Typography
-                variant="body2"
-                sx={{ fontWeight: 600, fontSize: '0.8125rem', color: 'text.primary' }}
-              >
-                {model}
-              </Typography>
+              <Tooltip title={model} placement="top">
+                <Typography
+                  variant="body2"
+                  noWrap
+                  sx={{
+                    fontWeight: 600,
+                    fontSize: '0.8125rem',
+                    color: 'text.primary',
+                    minWidth: 0,
+                  }}
+                >
+                  {model}
+                </Typography>
+              </Tooltip>
             </Box>
           )
 

--- a/apps/smartem/src/hooks/useImageNaturalSize.ts
+++ b/apps/smartem/src/hooks/useImageNaturalSize.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react'
+
+export interface ImageSize {
+  width: number
+  height: number
+}
+
+// Reads the intrinsic pixel dimensions of an (object-URL) image. The spatial overlays position
+// their markers in the image's native pixel space, so the SVG viewBox must match the real image
+// size rather than a hardcoded guess - otherwise a non-square image gets stretched and the overlay
+// drifts off it. Returns null until the image has decoded.
+export function useImageNaturalSize(url: string | undefined): ImageSize | null {
+  const [size, setSize] = useState<ImageSize | null>(null)
+
+  useEffect(() => {
+    if (!url) {
+      setSize(null)
+      return
+    }
+    let cancelled = false
+    const img = new Image()
+    img.onload = () => {
+      if (!cancelled) setSize({ width: img.naturalWidth, height: img.naturalHeight })
+    }
+    img.src = url
+    return () => {
+      cancelled = true
+    }
+  }, [url])
+
+  return size
+}

--- a/apps/smartem/src/hooks/useSquareMapData.ts
+++ b/apps/smartem/src/hooks/useSquareMapData.ts
@@ -1,0 +1,114 @@
+import {
+  getGetPredictionForGridsquarePredictionModelPredictionModelNameGridsquareGridsquareUuidPredictionGetQueryOptions as squarePredictionQueryOptions,
+  useGetGridsquareFoilholesGridsquaresGridsquareUuidFoilholesGet,
+  useGetGridsquareGridsquaresGridsquareUuidGet,
+  useGetOverallPredictionForGridsquareGridsquareGridsquareUuidOverallPredictionGet,
+  useGetPredictionModelsPredictionModelsGet,
+  useGetGridsquareImageGridsquaresGridsquareUuidGridsquareImageGet as useGridsquareImage,
+  useGetSuggestedHoleCollectionsGridsquaresGridsquareUuidPredictionModelPredictionModelNameLatentRepLatentRepModelNameSuggestedHolesGet as useSuggestedHoles,
+} from '@smartem/api'
+import { useQueries } from '@tanstack/react-query'
+import { useMemo } from 'react'
+import type { PredictionLayer } from '~/components/spatial/SquareMap'
+import {
+  foilHoleResponseToMock,
+  foilholePredictionMap,
+  gridSquareResponseToMock,
+  overallPredictionMap,
+} from '~/data/api-adapters'
+import type { MockFoilHole } from '~/data/mock-session-detail'
+import { useBlobObjectUrl } from './useBlobObjectUrl'
+
+export interface SquareMapData {
+  squareLabel: string
+  foilholes: MockFoilHole[]
+  imageUrl?: string
+  imageLoading: boolean
+  predictionLayers: PredictionLayer[]
+  predictionValues: Record<string, Map<string, number>>
+  suggestedHoleIds: Set<string>
+}
+
+// Fetches everything SquareMap needs for one gridsquare: foilhole geometry, the authenticated
+// micrograph blob, per-model + overall prediction overlays, and the suggested-holes set. Shared
+// by the full-page square view and the atlas-embedded preview panel so both stay in sync.
+export function useSquareMapData(squareId: string): SquareMapData {
+  const { data: squareResponse } = useGetGridsquareGridsquaresGridsquareUuidGet(squareId)
+  const { data: foilholeResponses } =
+    useGetGridsquareFoilholesGridsquaresGridsquareUuidFoilholesGet(squareId)
+  const { data: modelResponses } = useGetPredictionModelsPredictionModelsGet()
+  const { data: overallResponse } =
+    useGetOverallPredictionForGridsquareGridsquareGridsquareUuidOverallPredictionGet(squareId)
+  // Image route is auth-protected; fetch as an authenticated blob and hand the <image> element an
+  // object URL rather than a token-less direct URL.
+  const { data: squareImageBlob, isLoading: squareImageLoading } = useGridsquareImage(squareId)
+  const imageUrl = useBlobObjectUrl(squareImageBlob as Blob | undefined)
+  // "Pending" spans the blob fetch plus the extra tick useBlobObjectUrl needs to mint the object
+  // URL, so the overlay doesn't briefly flash in between the two.
+  const imageLoading = squareImageLoading || (!!squareImageBlob && !imageUrl)
+
+  const square = useMemo(
+    () => (squareResponse ? gridSquareResponseToMock(squareResponse) : null),
+    [squareResponse]
+  )
+  const foilholes = useMemo(
+    () => (foilholeResponses ?? []).map(foilHoleResponseToMock),
+    [foilholeResponses]
+  )
+
+  const models = useMemo(() => modelResponses ?? [], [modelResponses])
+
+  // One per-foilhole prediction query per model, scoped to this gridsquare.
+  const predictionResults = useQueries({
+    queries: models.map((m) => squarePredictionQueryOptions(m.name, squareId)),
+  })
+
+  // Assemble the selectable prediction layers (each model that returned data, plus the cross-model
+  // "overall") and their foilhole -> value maps for the square map overlay.
+  const { predictionLayers, predictionValues } = useMemo(() => {
+    const layers: PredictionLayer[] = []
+    const values: Record<string, Map<string, number>> = {}
+    models.forEach((m, i) => {
+      const map = foilholePredictionMap(predictionResults[i]?.data ?? [])
+      if (map.size > 0) {
+        layers.push({ id: m.name, label: m.name.split('-')[0] })
+        values[m.name] = map
+      }
+    })
+    if (overallResponse?.length) {
+      const overall = overallPredictionMap(overallResponse)
+      if (overall.size > 0) {
+        layers.push({ id: 'overall', label: 'Overall' })
+        values.overall = overall
+      }
+    }
+    return { predictionLayers: layers, predictionValues: values }
+  }, [models, predictionResults, overallResponse])
+
+  // Foilholes the system suggests collecting next. Mirrors the atlas suggested-squares endpoint: it
+  // needs a prediction model and a separate latent-rep model, but the API doesn't expose model
+  // types, so default to the first model for prediction and the second (if any) for the latent
+  // representation. Proper model-type distinction is tracked in #111.
+  const predictionModelName = models[0]?.name ?? ''
+  const latentModelName = models[1]?.name ?? models[0]?.name ?? ''
+  const { data: suggestedHoles } = useSuggestedHoles(
+    squareId,
+    predictionModelName,
+    latentModelName,
+    { query: { enabled: !!predictionModelName } }
+  )
+  const suggestedHoleIds = useMemo(
+    () => new Set((suggestedHoles ?? []).map((h) => h.uuid)),
+    [suggestedHoles]
+  )
+
+  return {
+    squareLabel: square?.gridsquareId ?? squareId,
+    foilholes,
+    imageUrl,
+    imageLoading,
+    predictionLayers,
+    predictionValues,
+    suggestedHoleIds,
+  }
+}

--- a/apps/smartem/src/hooks/useSquareMapData.ts
+++ b/apps/smartem/src/hooks/useSquareMapData.ts
@@ -18,12 +18,15 @@ import {
 } from '~/data/api-adapters'
 import type { MockFoilHole } from '~/data/mock-session-detail'
 import { useBlobObjectUrl } from './useBlobObjectUrl'
+import { useImageNaturalSize } from './useImageNaturalSize'
 
 export interface SquareMapData {
   squareLabel: string
   foilholes: MockFoilHole[]
   imageUrl?: string
   imageLoading: boolean
+  imageWidth?: number
+  imageHeight?: number
   predictionLayers: PredictionLayer[]
   predictionValues: Record<string, Map<string, number>>
   suggestedHoleIds: Set<string>
@@ -46,6 +49,7 @@ export function useSquareMapData(squareId: string): SquareMapData {
   // "Pending" spans the blob fetch plus the extra tick useBlobObjectUrl needs to mint the object
   // URL, so the overlay doesn't briefly flash in between the two.
   const imageLoading = squareImageLoading || (!!squareImageBlob && !imageUrl)
+  const naturalSize = useImageNaturalSize(imageUrl)
 
   const square = useMemo(
     () => (squareResponse ? gridSquareResponseToMock(squareResponse) : null),
@@ -107,6 +111,8 @@ export function useSquareMapData(squareId: string): SquareMapData {
     foilholes,
     imageUrl,
     imageLoading,
+    imageWidth: naturalSize?.width,
+    imageHeight: naturalSize?.height,
     predictionLayers,
     predictionValues,
     suggestedHoleIds,

--- a/apps/smartem/src/hooks/useSquareMapData.ts
+++ b/apps/smartem/src/hooks/useSquareMapData.ts
@@ -75,7 +75,7 @@ export function useSquareMapData(squareId: string): SquareMapData {
     models.forEach((m, i) => {
       const map = foilholePredictionMap(predictionResults[i]?.data ?? [])
       if (map.size > 0) {
-        layers.push({ id: m.name, label: m.name.split('-')[0] })
+        layers.push({ id: m.name, label: m.name })
         values[m.name] = map
       }
     })

--- a/apps/smartem/src/routes/__root.tsx
+++ b/apps/smartem/src/routes/__root.tsx
@@ -3,7 +3,7 @@ import { ThemeProvider } from '@mui/material/styles'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import { createRootRoute, Outlet } from '@tanstack/react-router'
-import { TanStackRouterDevtools } from '@tanstack/router-devtools'
+import { TanStackRouterDevtools } from '@tanstack/react-router-devtools'
 import { ErrorBoundary } from '~/components/ErrorBoundary'
 import { Header } from '~/components/shell/Header'
 import { theme } from '~/theme'
@@ -16,6 +16,11 @@ const queryClient = new QueryClient({
     },
   },
 })
+
+// The TanStack Router + Query devtools float over the bottom corners of the UI. Show them in dev by
+// default, but let a local `.env.local` opt out with VITE_DEVTOOLS=false when they obscure the layout;
+// never render them in a production build.
+const showDevtools = import.meta.env.DEV && import.meta.env.VITE_DEVTOOLS !== 'false'
 
 export const Route = createRootRoute({
   component: RootComponent,
@@ -37,8 +42,8 @@ function RootComponent() {
             </ErrorBoundary>
           </Box>
         </Box>
-        <TanStackRouterDevtools />
-        {import.meta.env.DEV && <ReactQueryDevtools initialIsOpen={false} />}
+        {showDevtools && <TanStackRouterDevtools />}
+        {showDevtools && <ReactQueryDevtools initialIsOpen={false} />}
       </QueryClientProvider>
     </ThemeProvider>
   )

--- a/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.atlas.tsx
+++ b/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.atlas.tsx
@@ -1,4 +1,4 @@
-import { Box, IconButton, Tooltip, Typography } from '@mui/material'
+import { Box, IconButton, Tooltip } from '@mui/material'
 import {
   getGetPredictionForGridPredictionModelPredictionModelNameGridGridUuidPredictionGetQueryOptions as gridPredictionQueryOptions,
   getGetLatentRepPredictionModelPredictionModelNameGridGridUuidLatentRepresentationGetQueryOptions as latentRepQueryOptions,
@@ -229,38 +229,15 @@ function AtlasView() {
         }}
       >
         {showLatent ? (
-          <Box
-            sx={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden' }}
-          >
-            <Box
-              sx={{
-                display: 'flex',
-                alignItems: 'center',
-                px: 1.5,
-                height: 28,
-                backgroundColor: gray[100],
-                borderBottom: '1px solid',
-                borderColor: 'divider',
-                flexShrink: 0,
-              }}
-            >
-              <Typography variant="caption" sx={{ fontWeight: 600, fontSize: '0.6875rem' }}>
-                Latent Space
-              </Typography>
-              <Box sx={{ flex: 1 }} />
-              <CloseButton onClick={() => setShowLatent(false)} />
-            </Box>
-            <Box sx={{ flex: 1, overflow: 'hidden' }}>
-              <LatentSpacePanel
-                items={latentItems}
-                selectedId={selectedSquareId}
-                onItemClick={lockSquare}
-                onItemHover={(id) => {
-                  if (!frozen) setSelectedSquareId(id)
-                }}
-              />
-            </Box>
-          </Box>
+          <LatentSpacePanel
+            items={latentItems}
+            selectedId={selectedSquareId}
+            onItemClick={lockSquare}
+            onItemHover={(id) => {
+              if (!frozen) setSelectedSquareId(id)
+            }}
+            onClose={() => setShowLatent(false)}
+          />
         ) : committedSquareId ? (
           <SquarePreviewPanel
             acquisitionId={acquisitionId}
@@ -273,15 +250,5 @@ function AtlasView() {
         )}
       </Box>
     </Box>
-  )
-}
-
-function CloseButton({ onClick }: { onClick: () => void }) {
-  return (
-    <IconButton onClick={onClick} size="small" sx={{ p: 0.25 }}>
-      <svg width="12" height="12" viewBox="0 0 12 12" fill="none" role="img" aria-label="Close">
-        <path d="M3 3l6 6M9 3l-6 6" stroke={gray[600]} strokeWidth="1.5" strokeLinecap="round" />
-      </svg>
-    </IconButton>
   )
 }

--- a/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.atlas.tsx
+++ b/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.atlas.tsx
@@ -12,6 +12,7 @@ import { useQueries } from '@tanstack/react-query'
 import { createFileRoute } from '@tanstack/react-router'
 import { useMemo, useState } from 'react'
 import { AtlasMap } from '~/components/spatial/AtlasMap'
+import { EmptySquarePanel } from '~/components/spatial/EmptySquarePanel'
 import { LatentSpacePanel } from '~/components/spatial/LatentSpacePanel'
 import { SquarePreviewPanel } from '~/components/spatial/SquarePreviewPanel'
 import {
@@ -134,10 +135,10 @@ function AtlasView() {
     [squares]
   )
 
-  // Clicking a square locks it and opens the side-by-side grid-square preview (issue #68). Hover
-  // only highlights - the heavy micrograph loads on this explicit commit, not on hover. Opening the
-  // preview hides the latent panel so only one right-hand panel shows at a time.
-  const previewOpen = frozen && selectedSquareId !== null
+  // Clicking a square commits it (issue #68): hover only highlights, the heavy micrograph loads on the
+  // explicit commit. The right-hand panel is always present (committed square / latent space / empty
+  // placeholder), so the atlas never reflows when a square is picked.
+  const committedSquareId = frozen ? selectedSquareId : null
 
   const lockSquare = (uuid: string) => {
     setSelectedSquareId(uuid)
@@ -151,8 +152,9 @@ function AtlasView() {
   }
 
   return (
-    <Box sx={{ display: 'flex', height: '100%', overflow: 'hidden', position: 'relative' }}>
-      <Box sx={{ flex: 1, overflow: 'hidden', minWidth: 0 }}>
+    <Box sx={{ display: 'flex', height: '100%', overflow: 'hidden' }}>
+      {/* Atlas pane - always the complementary width of the persistent panel, so it never reflows. */}
+      <Box sx={{ flex: 1, overflow: 'hidden', minWidth: 0, position: 'relative' }}>
         <AtlasMap
           squares={squares}
           gridName={grid?.name ?? gridId}
@@ -177,113 +179,99 @@ function AtlasView() {
             }
           }}
         />
-      </Box>
 
-      {/* Grid-square preview panel (issue #68): atlas + selected square side by side. The container
-          stays mounted and animates its width so the atlas reflows smoothly instead of snapping; the
-          panel contents (and their image fetch) mount only while open. */}
-      <Box
-        sx={{
-          // Responsive split (percentage of the window, no fixed px cap): the panel takes ~42% of
-          // the row when open and the atlas (flex: 1) reflows into the rest. Width animates so the
-          // atlas slides over rather than snapping, and the split scales with the window.
-          flexShrink: 0,
-          width: previewOpen ? '42%' : 0,
-          minWidth: 0,
-          borderLeft: previewOpen ? '1px solid' : '0px solid',
-          borderColor: 'divider',
-          overflow: 'hidden',
-          transition: 'width 0.22s ease',
-        }}
-      >
-        {previewOpen && selectedSquareId && (
-          <SquarePreviewPanel
-            acquisitionId={acquisitionId}
-            gridId={gridId}
-            squareId={selectedSquareId}
-            onClose={closePreview}
-          />
+        {/* Open latent space - floats over the atlas, top-right, while the latent panel is closed. */}
+        {!showLatent && (
+          <Tooltip title="Show latent space" placement="left">
+            <IconButton
+              onClick={() => setShowLatent(true)}
+              size="small"
+              sx={{
+                position: 'absolute',
+                right: 12,
+                top: 12,
+                zIndex: 5,
+                backgroundColor: '#ffffff',
+                border: '1px solid',
+                borderColor: 'divider',
+                '&:hover': { backgroundColor: gray[100] },
+              }}
+            >
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 16 16"
+                fill="none"
+                role="img"
+                aria-label="Scatter plot"
+              >
+                <circle cx="4" cy="12" r="2" fill="#5878a3" />
+                <circle cx="7" cy="5" r="2" fill="#e59344" />
+                <circle cx="12" cy="9" r="2" fill="#6ba059" />
+                <circle cx="10" cy="3" r="1.5" fill="#d1605e" />
+                <circle cx="3" cy="7" r="1.5" fill="#a77c9f" />
+              </svg>
+            </IconButton>
+          </Tooltip>
         )}
       </Box>
 
-      {/* Latent space side panel */}
-      {!previewOpen && showLatent && (
-        <Box
-          sx={{
-            width: 360,
-            flexShrink: 0,
-            borderLeft: '1px solid',
-            borderColor: 'divider',
-            display: 'flex',
-            flexDirection: 'column',
-            overflow: 'hidden',
-          }}
-        >
+      {/* Persistent right-hand panel (issue #68): latent space, the committed grid square, or an empty
+          placeholder. Fixed share of the row so the atlas keeps its position when a square is clicked. */}
+      <Box
+        sx={{
+          flexShrink: 0,
+          width: '42%',
+          minWidth: 0,
+          borderLeft: '1px solid',
+          borderColor: 'divider',
+          overflow: 'hidden',
+        }}
+      >
+        {showLatent ? (
           <Box
-            sx={{
-              display: 'flex',
-              alignItems: 'center',
-              px: 1.5,
-              height: 28,
-              backgroundColor: gray[100],
-              borderBottom: '1px solid',
-              borderColor: 'divider',
-              flexShrink: 0,
-            }}
+            sx={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden' }}
           >
-            <Typography variant="caption" sx={{ fontWeight: 600, fontSize: '0.6875rem' }}>
-              Latent Space
-            </Typography>
-            <Box sx={{ flex: 1 }} />
-            <CloseButton onClick={() => setShowLatent(false)} />
-          </Box>
-          <Box sx={{ flex: 1, overflow: 'hidden' }}>
-            <LatentSpacePanel
-              items={latentItems}
-              selectedId={selectedSquareId}
-              onItemClick={lockSquare}
-              onItemHover={(id) => {
-                if (!frozen) setSelectedSquareId(id)
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                px: 1.5,
+                height: 28,
+                backgroundColor: gray[100],
+                borderBottom: '1px solid',
+                borderColor: 'divider',
+                flexShrink: 0,
               }}
-            />
-          </Box>
-        </Box>
-      )}
-
-      {/* Floating action button to open latent panel */}
-      {!previewOpen && !showLatent && (
-        <Tooltip title="Show latent space" placement="left">
-          <IconButton
-            onClick={() => setShowLatent(true)}
-            size="small"
-            sx={{
-              position: 'absolute',
-              right: 12,
-              top: 12,
-              zIndex: 5,
-              backgroundColor: '#ffffff',
-              border: '1px solid',
-              borderColor: 'divider',
-              '&:hover': { backgroundColor: gray[100] },
-            }}
-          >
-            <svg
-              width="16"
-              height="16"
-              viewBox="0 0 16 16"
-              fill="none"
-              role="img"
-              aria-label="Scatter plot"
             >
-              <circle cx="4" cy="12" r="2" fill="#5878a3" />
-              <circle cx="7" cy="5" r="2" fill="#e59344" />
-              <circle cx="12" cy="9" r="2" fill="#6ba059" />
-              <circle cx="10" cy="3" r="1.5" fill="#d1605e" />
-              <circle cx="3" cy="7" r="1.5" fill="#a77c9f" />
-            </svg>
-          </IconButton>
-        </Tooltip>
-      )}
+              <Typography variant="caption" sx={{ fontWeight: 600, fontSize: '0.6875rem' }}>
+                Latent Space
+              </Typography>
+              <Box sx={{ flex: 1 }} />
+              <CloseButton onClick={() => setShowLatent(false)} />
+            </Box>
+            <Box sx={{ flex: 1, overflow: 'hidden' }}>
+              <LatentSpacePanel
+                items={latentItems}
+                selectedId={selectedSquareId}
+                onItemClick={lockSquare}
+                onItemHover={(id) => {
+                  if (!frozen) setSelectedSquareId(id)
+                }}
+              />
+            </Box>
+          </Box>
+        ) : committedSquareId ? (
+          <SquarePreviewPanel
+            acquisitionId={acquisitionId}
+            gridId={gridId}
+            squareId={committedSquareId}
+            onClose={closePreview}
+          />
+        ) : (
+          <EmptySquarePanel />
+        )}
+      </Box>
     </Box>
   )
 }

--- a/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.atlas.tsx
+++ b/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.atlas.tsx
@@ -23,6 +23,7 @@ import {
 } from '~/data/api-adapters'
 import type { MockLatentCoords } from '~/data/mock-session-detail'
 import { useBlobObjectUrl } from '~/hooks/useBlobObjectUrl'
+import { useImageNaturalSize } from '~/hooks/useImageNaturalSize'
 import { gray } from '~/theme'
 
 export const Route = createFileRoute('/acquisitions/$acquisitionId/grids/$gridId/atlas')({
@@ -41,6 +42,7 @@ function AtlasView() {
     undefined
   )
   const atlasImageUrl = useBlobObjectUrl(atlasImageBlob as Blob | undefined)
+  const atlasSize = useImageNaturalSize(atlasImageUrl)
   // "Pending" spans the whole wait: the blob fetch plus the extra tick useBlobObjectUrl needs
   // to mint the object URL. Without the second term the overlay would briefly flash in between
   // the fetch resolving and the URL existing.
@@ -156,6 +158,8 @@ function AtlasView() {
           gridName={grid?.name ?? gridId}
           imageUrl={atlasImageUrl}
           imageLoading={atlasImagePending}
+          imageWidth={atlasSize?.width}
+          imageHeight={atlasSize?.height}
           onSquareClick={lockSquare}
           predictions={predictions}
           models={models}
@@ -175,26 +179,28 @@ function AtlasView() {
         />
       </Box>
 
-      {/* Grid-square preview panel (issue #68): atlas + selected square side by side */}
-      {previewOpen && selectedSquareId && (
-        <Box
-          sx={{
-            flex: '1 1 0',
-            minWidth: 320,
-            maxWidth: 760,
-            borderLeft: '1px solid',
-            borderColor: 'divider',
-            overflow: 'hidden',
-          }}
-        >
+      {/* Grid-square preview panel (issue #68): atlas + selected square side by side. The container
+          stays mounted and animates its width so the atlas reflows smoothly instead of snapping; the
+          panel contents (and their image fetch) mount only while open. */}
+      <Box
+        sx={{
+          flexShrink: 0,
+          width: previewOpen ? 'min(46%, 760px)' : 0,
+          borderLeft: previewOpen ? '1px solid' : '0px solid',
+          borderColor: 'divider',
+          overflow: 'hidden',
+          transition: 'width 0.22s ease',
+        }}
+      >
+        {previewOpen && selectedSquareId && (
           <SquarePreviewPanel
             acquisitionId={acquisitionId}
             gridId={gridId}
             squareId={selectedSquareId}
             onClose={closePreview}
           />
-        </Box>
-      )}
+        )}
+      </Box>
 
       {/* Latent space side panel */}
       {!previewOpen && showLatent && (

--- a/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.atlas.tsx
+++ b/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.atlas.tsx
@@ -184,8 +184,12 @@ function AtlasView() {
           panel contents (and their image fetch) mount only while open. */}
       <Box
         sx={{
+          // Responsive split (percentage of the window, no fixed px cap): the panel takes ~42% of
+          // the row when open and the atlas (flex: 1) reflows into the rest. Width animates so the
+          // atlas slides over rather than snapping, and the split scales with the window.
           flexShrink: 0,
-          width: previewOpen ? 'min(46%, 760px)' : 0,
+          width: previewOpen ? '42%' : 0,
+          minWidth: 0,
           borderLeft: previewOpen ? '1px solid' : '0px solid',
           borderColor: 'divider',
           overflow: 'hidden',

--- a/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.atlas.tsx
+++ b/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.atlas.tsx
@@ -221,7 +221,7 @@ function AtlasView() {
       <Box
         sx={{
           flexShrink: 0,
-          width: '42%',
+          width: '50%',
           minWidth: 0,
           borderLeft: '1px solid',
           borderColor: 'divider',

--- a/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.atlas.tsx
+++ b/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.atlas.tsx
@@ -9,10 +9,11 @@ import {
   useGetSuggestedSquareCollectionsGridGridUuidPredictionModelPredictionModelNameLatentRepLatentRepModelNameSuggestedSquaresGet as useSuggestedSquares,
 } from '@smartem/api'
 import { useQueries } from '@tanstack/react-query'
-import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { createFileRoute } from '@tanstack/react-router'
 import { useMemo, useState } from 'react'
 import { AtlasMap } from '~/components/spatial/AtlasMap'
 import { LatentSpacePanel } from '~/components/spatial/LatentSpacePanel'
+import { SquarePreviewPanel } from '~/components/spatial/SquarePreviewPanel'
 import {
   gridResponseToMock,
   gridSquareResponseToMock,
@@ -30,7 +31,6 @@ export const Route = createFileRoute('/acquisitions/$acquisitionId/grids/$gridId
 
 function AtlasView() {
   const { acquisitionId, gridId } = Route.useParams()
-  const navigate = useNavigate()
   const { data: gridResponse } = useGetGridGridsGridUuidGet(gridId)
   const { data: squareResponses } = useGetGridGridsquaresGridsGridUuidGridsquaresGet(gridId)
   const { data: modelResponses } = useGetPredictionModelsPredictionModelsGet()
@@ -132,32 +132,31 @@ function AtlasView() {
     [squares]
   )
 
-  const handleSquareClick = (uuid: string) => {
-    if (frozen && uuid === selectedSquareId) {
-      setFrozen(false)
-      setSelectedSquareId(null)
-    } else {
-      setFrozen(true)
-      setSelectedSquareId(uuid)
-    }
+  // Clicking a square locks it and opens the side-by-side grid-square preview (issue #68). Hover
+  // only highlights - the heavy micrograph loads on this explicit commit, not on hover. Opening the
+  // preview hides the latent panel so only one right-hand panel shows at a time.
+  const previewOpen = frozen && selectedSquareId !== null
+
+  const lockSquare = (uuid: string) => {
+    setSelectedSquareId(uuid)
+    setFrozen(true)
+    setShowLatent(false)
   }
 
-  const handleSquareNavigate = (uuid: string) => {
-    navigate({
-      to: '/acquisitions/$acquisitionId/grids/$gridId/squares/$squareId',
-      params: { acquisitionId, gridId, squareId: uuid },
-    })
+  const closePreview = () => {
+    setFrozen(false)
+    setSelectedSquareId(null)
   }
 
   return (
-    <Box sx={{ display: 'flex', height: '100%', overflow: 'hidden' }}>
-      <Box sx={{ flex: 1, overflow: 'hidden' }}>
+    <Box sx={{ display: 'flex', height: '100%', overflow: 'hidden', position: 'relative' }}>
+      <Box sx={{ flex: 1, overflow: 'hidden', minWidth: 0 }}>
         <AtlasMap
           squares={squares}
           gridName={grid?.name ?? gridId}
           imageUrl={atlasImageUrl}
           imageLoading={atlasImagePending}
-          onSquareClick={handleSquareNavigate}
+          onSquareClick={lockSquare}
           predictions={predictions}
           models={models}
           suggestedSquareIds={suggestedSquareIds}
@@ -167,14 +166,38 @@ function AtlasView() {
           }}
           frozenSelection={frozen}
           onFreezeToggle={() => {
-            setFrozen((f) => !f)
-            if (frozen) setSelectedSquareId(null)
+            if (frozen) closePreview()
+            else {
+              setFrozen(true)
+              setShowLatent(false)
+            }
           }}
         />
       </Box>
 
+      {/* Grid-square preview panel (issue #68): atlas + selected square side by side */}
+      {previewOpen && selectedSquareId && (
+        <Box
+          sx={{
+            flex: '1 1 0',
+            minWidth: 320,
+            maxWidth: 760,
+            borderLeft: '1px solid',
+            borderColor: 'divider',
+            overflow: 'hidden',
+          }}
+        >
+          <SquarePreviewPanel
+            acquisitionId={acquisitionId}
+            gridId={gridId}
+            squareId={selectedSquareId}
+            onClose={closePreview}
+          />
+        </Box>
+      )}
+
       {/* Latent space side panel */}
-      {showLatent && (
+      {!previewOpen && showLatent && (
         <Box
           sx={{
             width: 360,
@@ -208,7 +231,7 @@ function AtlasView() {
             <LatentSpacePanel
               items={latentItems}
               selectedId={selectedSquareId}
-              onItemClick={handleSquareClick}
+              onItemClick={lockSquare}
               onItemHover={(id) => {
                 if (!frozen) setSelectedSquareId(id)
               }}
@@ -218,7 +241,7 @@ function AtlasView() {
       )}
 
       {/* Floating action button to open latent panel */}
-      {!showLatent && (
+      {!previewOpen && !showLatent && (
         <Tooltip title="Show latent space" placement="left">
           <IconButton
             onClick={() => setShowLatent(true)}

--- a/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.squares_.$squareId.index.tsx
+++ b/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.squares_.$squareId.index.tsx
@@ -1,23 +1,6 @@
-import {
-  getGetPredictionForGridsquarePredictionModelPredictionModelNameGridsquareGridsquareUuidPredictionGetQueryOptions as squarePredictionQueryOptions,
-  useGetGridsquareFoilholesGridsquaresGridsquareUuidFoilholesGet,
-  useGetGridsquareGridsquaresGridsquareUuidGet,
-  useGetOverallPredictionForGridsquareGridsquareGridsquareUuidOverallPredictionGet,
-  useGetPredictionModelsPredictionModelsGet,
-  useGetGridsquareImageGridsquaresGridsquareUuidGridsquareImageGet as useGridsquareImage,
-  useGetSuggestedHoleCollectionsGridsquaresGridsquareUuidPredictionModelPredictionModelNameLatentRepLatentRepModelNameSuggestedHolesGet as useSuggestedHoles,
-} from '@smartem/api'
-import { useQueries } from '@tanstack/react-query'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
-import { useMemo } from 'react'
-import { type PredictionLayer, SquareMap } from '~/components/spatial/SquareMap'
-import {
-  foilHoleResponseToMock,
-  foilholePredictionMap,
-  gridSquareResponseToMock,
-  overallPredictionMap,
-} from '~/data/api-adapters'
-import { useBlobObjectUrl } from '~/hooks/useBlobObjectUrl'
+import { SquareMap } from '~/components/spatial/SquareMap'
+import { useSquareMapData } from '~/hooks/useSquareMapData'
 
 export const Route = createFileRoute(
   '/acquisitions/$acquisitionId/grids/$gridId/squares_/$squareId/'
@@ -28,81 +11,22 @@ export const Route = createFileRoute(
 function SquareIndexView() {
   const { acquisitionId, gridId, squareId } = Route.useParams()
   const navigate = useNavigate()
-  const { data: squareResponse } = useGetGridsquareGridsquaresGridsquareUuidGet(squareId)
-  const { data: foilholeResponses } =
-    useGetGridsquareFoilholesGridsquaresGridsquareUuidFoilholesGet(squareId)
-  const { data: modelResponses } = useGetPredictionModelsPredictionModelsGet()
-  const { data: overallResponse } =
-    useGetOverallPredictionForGridsquareGridsquareGridsquareUuidOverallPredictionGet(squareId)
-  // Image route is auth-protected; fetch as an authenticated blob and hand the
-  // <image> element an object URL rather than a token-less direct URL.
-  const { data: squareImageBlob, isLoading: squareImageLoading } = useGridsquareImage(squareId)
-  const squareImageUrl = useBlobObjectUrl(squareImageBlob as Blob | undefined)
-  // "Pending" spans the blob fetch plus the extra tick useBlobObjectUrl needs to mint the
-  // object URL, so the overlay doesn't briefly flash in between the two.
-  const squareImagePending = squareImageLoading || (!!squareImageBlob && !squareImageUrl)
-
-  const square = useMemo(
-    () => (squareResponse ? gridSquareResponseToMock(squareResponse) : null),
-    [squareResponse]
-  )
-  const foilholes = useMemo(
-    () => (foilholeResponses ?? []).map(foilHoleResponseToMock),
-    [foilholeResponses]
-  )
-
-  const models = useMemo(() => modelResponses ?? [], [modelResponses])
-
-  // One per-foilhole prediction query per model, scoped to this gridsquare.
-  const predictionResults = useQueries({
-    queries: models.map((m) => squarePredictionQueryOptions(m.name, squareId)),
-  })
-
-  // Assemble the selectable prediction layers (each model that returned data, plus the
-  // cross-model "overall") and their foilhole -> value maps for the square map overlay.
-  const { predictionLayers, predictionValues } = useMemo(() => {
-    const layers: PredictionLayer[] = []
-    const values: Record<string, Map<string, number>> = {}
-    models.forEach((m, i) => {
-      const map = foilholePredictionMap(predictionResults[i]?.data ?? [])
-      if (map.size > 0) {
-        layers.push({ id: m.name, label: m.name.split('-')[0] })
-        values[m.name] = map
-      }
-    })
-    if (overallResponse?.length) {
-      const overall = overallPredictionMap(overallResponse)
-      if (overall.size > 0) {
-        layers.push({ id: 'overall', label: 'Overall' })
-        values.overall = overall
-      }
-    }
-    return { predictionLayers: layers, predictionValues: values }
-  }, [models, predictionResults, overallResponse])
-
-  // Foilholes the system suggests collecting next. Mirrors the atlas suggested-squares endpoint:
-  // it needs a prediction model and a separate latent-rep model, but the API doesn't expose model
-  // types, so default to the first model for prediction and the second (if any) for the latent
-  // representation. Proper model-type distinction is tracked in #111.
-  const predictionModelName = models[0]?.name ?? ''
-  const latentModelName = models[1]?.name ?? models[0]?.name ?? ''
-  const { data: suggestedHoles } = useSuggestedHoles(
-    squareId,
-    predictionModelName,
-    latentModelName,
-    { query: { enabled: !!predictionModelName } }
-  )
-  const suggestedHoleIds = useMemo(
-    () => new Set((suggestedHoles ?? []).map((h) => h.uuid)),
-    [suggestedHoles]
-  )
+  const {
+    foilholes,
+    squareLabel,
+    imageUrl,
+    imageLoading,
+    predictionLayers,
+    predictionValues,
+    suggestedHoleIds,
+  } = useSquareMapData(squareId)
 
   return (
     <SquareMap
       foilholes={foilholes}
-      squareLabel={square?.gridsquareId ?? squareId}
-      imageUrl={squareImageUrl}
-      imageLoading={squareImagePending}
+      squareLabel={squareLabel}
+      imageUrl={imageUrl}
+      imageLoading={imageLoading}
       predictionLayers={predictionLayers}
       predictionValues={predictionValues}
       suggestedHoleIds={suggestedHoleIds}

--- a/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.squares_.$squareId.index.tsx
+++ b/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.squares_.$squareId.index.tsx
@@ -16,6 +16,8 @@ function SquareIndexView() {
     squareLabel,
     imageUrl,
     imageLoading,
+    imageWidth,
+    imageHeight,
     predictionLayers,
     predictionValues,
     suggestedHoleIds,
@@ -27,6 +29,8 @@ function SquareIndexView() {
       squareLabel={squareLabel}
       imageUrl={imageUrl}
       imageLoading={imageLoading}
+      imageWidth={imageWidth}
+      imageHeight={imageHeight}
       predictionLayers={predictionLayers}
       predictionValues={predictionValues}
       suggestedHoleIds={suggestedHoleIds}

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "@smartem/ui": "*",
         "@tanstack/react-query": "^5.100.6",
         "@tanstack/react-router": "^1.168.3",
-        "@tanstack/router-devtools": "^1.166.11",
+        "@tanstack/react-router-devtools": "^1.166.13",
         "keycloak-js": "^26.1.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4"


### PR DESCRIPTION
## What

Closes #68. Clicking a square on the atlas now **locks it and opens a Grid Square panel to the right**, so the selected square sits beside the atlas instead of replacing it - matching the PATo reference on the issue.

- New `SquarePreviewPanel` renders the same `SquareMap` the full-page square view uses (foilhole overlay, metric/prediction selector, suggestions, legend), plus an **"Open full view"** link and a close control.
- Extracted the square data-fetching (foilholes, authenticated micrograph blob, per-model + overall prediction overlays, suggested holes) into a shared **`useSquareMapData`** hook, so the panel and the full page can't drift apart.
- The latent-space panel and the grid-square panel are **mutually exclusive** - only one right-hand panel at a time, keeping the layout clean (atlas + one panel).

## Interaction: load-on-commit

Hover only **highlights** a square; the multi-MB micrograph loads on an **explicit click**, never on hover. A hover-sweep across the atlas would otherwise fire dozens of multi-MB image fetches at the backend (which already OOMs on the atlas fan-out). Click = exactly one fetch per square the user actually picks; React Query caches it on revisit.

This "heavy imagery loads on commit, not hover" principle is coupled to the parked image-serving/zoom decision (#111) - if we go tiled/zoomable, the calculus changes - so it's flagged there rather than written as its own ADR.

Single-click no longer navigates away; the full square page is reached via the panel's "Open full view" link.

## Verification

- `npm run typecheck`, `biome check`, `npm run build:smartem` - all clean.
- Driven against the local k3s prod dump: opened a 310-square atlas, clicked a square, and confirmed the Grid Square panel renders the **real micrograph with its 155-foilhole overlay** beside the atlas; "Open full view" present; closing the panel returns to the atlas. (The `/version` 401s and a `gridsquare_image` 404 on some squares are pre-existing - the latter is the partial on-disk image coverage tracked under the image-path-resolution work, not this change.)

Closes #68
