### PR TITLE
feat(smartem): square latent-space panel + grid-square gallery (parity #132 A1/A2)

### DIFF
--- a/apps/smartem/src/components/session/ViewSwitcher.tsx
+++ b/apps/smartem/src/components/session/ViewSwitcher.tsx
@@ -36,7 +36,11 @@ export function ViewSwitcher() {
 
       {tabs.map((tab) => {
         const to = `/acquisitions/${acquisitionId}/grids/${gridId}${tab.suffix}`
-        const isActive = pathname.endsWith(tab.suffix)
+        // Squares has a Table/Gallery sub-route, so keep the tab active on either.
+        const isActive =
+          tab.key === 'squares'
+            ? pathname.endsWith('/squares') || pathname.endsWith('/squares/gallery')
+            : pathname.endsWith(tab.suffix)
         return (
           <ButtonBase
             key={tab.key}

--- a/apps/smartem/src/components/spatial/LatentSpacePanel.tsx
+++ b/apps/smartem/src/components/spatial/LatentSpacePanel.tsx
@@ -5,7 +5,7 @@ import type { MockLatentCoords } from '~/data/mock-session-detail'
 import { gray } from '~/theme'
 import { CLUSTER_PALETTE } from '~/utils/heatmap'
 
-interface LatentSpaceItem {
+export interface LatentSpaceItem {
   id: string
   label: string
   latent: MockLatentCoords

--- a/apps/smartem/src/components/spatial/SquareMap.tsx
+++ b/apps/smartem/src/components/spatial/SquareMap.tsx
@@ -68,6 +68,10 @@ interface SquareMapProps {
   imageWidth?: number
   imageHeight?: number
   onFoilholeClick?: (uuid: string) => void
+  // Optional controlled hover. When provided, the hovered foilhole is owned by the caller so the
+  // map and a sibling view (the latent-space panel) can cross-highlight; left uncontrolled otherwise.
+  hoveredId?: string | null
+  onHoveredIdChange?: (uuid: string | null) => void
   predictionLayers?: PredictionLayer[]
   // layer id -> (foilhole uuid -> predicted value, 0..1)
   predictionValues?: Record<string, Map<string, number>>
@@ -91,6 +95,8 @@ export function SquareMap({
   imageWidth,
   imageHeight,
   onFoilholeClick,
+  hoveredId: controlledHoveredId,
+  onHoveredIdChange,
   predictionLayers = [],
   predictionValues = {},
   suggestedHoleIds,
@@ -98,7 +104,9 @@ export function SquareMap({
   onClose,
   onExpand,
 }: SquareMapProps) {
-  const [hoveredId, setHoveredId] = useState<string | null>(null)
+  const [internalHoveredId, setInternalHoveredId] = useState<string | null>(null)
+  // Controlled when the caller passes hoveredId; otherwise the map owns it.
+  const hoveredId = controlledHoveredId !== undefined ? controlledHoveredId : internalHoveredId
   const [selectedId, setSelectedId] = useState<string | null>(null)
   const [selectionFrozen, setSelectionFrozen] = useState(false)
   const [tooltipPos, setTooltipPos] = useState({ x: 0, y: 0 })
@@ -192,10 +200,11 @@ export function SquareMap({
   const handleHover = useCallback(
     (uuid: string | null) => {
       if (!selectionFrozen) {
-        setHoveredId(uuid)
+        if (onHoveredIdChange) onHoveredIdChange(uuid)
+        else setInternalHoveredId(uuid)
       }
     },
-    [selectionFrozen]
+    [selectionFrozen, onHoveredIdChange]
   )
 
   const hoveredHole = hoveredId ? foilholes.find((h) => h.uuid === hoveredId) : null

--- a/apps/smartem/src/data/api-adapters.ts
+++ b/apps/smartem/src/data/api-adapters.ts
@@ -194,6 +194,20 @@ export function latentResponsesToCoordsByUuid(
   return byUuid
 }
 
+// Maps a gridsquare's latent-representation response to per-foilhole coordinates for the
+// square-level latent-space scatter. Keyed by foilhole uuid (vs the grid version's square
+// uuid); rows without coordinates are skipped.
+export function latentResponsesToCoordsByFoilhole(
+  responses: LatentRepresentationResponse[]
+): Map<string, MockLatentCoords> {
+  const byUuid = new Map<string, MockLatentCoords>()
+  for (const r of responses) {
+    if (r.foilhole_uuid == null || r.x == null || r.y == null) continue
+    byUuid.set(r.foilhole_uuid, { x: r.x, y: r.y, clusterIndex: r.index ?? 0 })
+  }
+  return byUuid
+}
+
 // Latest predicted value per foilhole for one (model, gridsquare), keyed by foilhole uuid -
 // drives the per-model prediction overlay on the square map.
 export function foilholePredictionMap(responses: QualityPredictionResponse[]): Map<string, number> {

--- a/apps/smartem/src/routeTree.gen.ts
+++ b/apps/smartem/src/routeTree.gen.ts
@@ -23,7 +23,9 @@ import { Route as AcquisitionsAcquisitionIdGridsGridIdWorkspaceRouteImport } fro
 import { Route as AcquisitionsAcquisitionIdGridsGridIdSquaresRouteImport } from './routes/acquisitions.$acquisitionId.grids.$gridId.squares'
 import { Route as AcquisitionsAcquisitionIdGridsGridIdPredictionsRouteImport } from './routes/acquisitions.$acquisitionId.grids.$gridId.predictions'
 import { Route as AcquisitionsAcquisitionIdGridsGridIdAtlasRouteImport } from './routes/acquisitions.$acquisitionId.grids.$gridId.atlas'
+import { Route as AcquisitionsAcquisitionIdGridsGridIdSquaresIndexRouteImport } from './routes/acquisitions.$acquisitionId.grids.$gridId.squares.index'
 import { Route as AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdRouteImport } from './routes/acquisitions.$acquisitionId.grids.$gridId.squares_.$squareId'
+import { Route as AcquisitionsAcquisitionIdGridsGridIdSquaresGalleryRouteImport } from './routes/acquisitions.$acquisitionId.grids.$gridId.squares.gallery'
 import { Route as AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdIndexRouteImport } from './routes/acquisitions.$acquisitionId.grids.$gridId.squares_.$squareId.index'
 import { Route as AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdPredictionsRouteImport } from './routes/acquisitions.$acquisitionId.grids.$gridId.squares_.$squareId.predictions'
 import { Route as AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdHolesHoleIdRouteImport } from './routes/acquisitions.$acquisitionId.grids.$gridId.squares_.$squareId.holes_.$holeId'
@@ -106,11 +108,23 @@ const AcquisitionsAcquisitionIdGridsGridIdAtlasRoute =
     path: '/atlas',
     getParentRoute: () => AcquisitionsAcquisitionIdGridsGridIdRoute,
   } as any)
+const AcquisitionsAcquisitionIdGridsGridIdSquaresIndexRoute =
+  AcquisitionsAcquisitionIdGridsGridIdSquaresIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => AcquisitionsAcquisitionIdGridsGridIdSquaresRoute,
+  } as any)
 const AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdRoute =
   AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdRouteImport.update({
     id: '/squares_/$squareId',
     path: '/squares/$squareId',
     getParentRoute: () => AcquisitionsAcquisitionIdGridsGridIdRoute,
+  } as any)
+const AcquisitionsAcquisitionIdGridsGridIdSquaresGalleryRoute =
+  AcquisitionsAcquisitionIdGridsGridIdSquaresGalleryRouteImport.update({
+    id: '/gallery',
+    path: '/gallery',
+    getParentRoute: () => AcquisitionsAcquisitionIdGridsGridIdSquaresRoute,
   } as any)
 const AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdIndexRoute =
   AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdIndexRouteImport.update({
@@ -150,10 +164,12 @@ export interface FileRoutesByFullPath {
   '/acquisitions/$acquisitionId/grids/$gridId': typeof AcquisitionsAcquisitionIdGridsGridIdRouteWithChildren
   '/acquisitions/$acquisitionId/grids/$gridId/atlas': typeof AcquisitionsAcquisitionIdGridsGridIdAtlasRoute
   '/acquisitions/$acquisitionId/grids/$gridId/predictions': typeof AcquisitionsAcquisitionIdGridsGridIdPredictionsRoute
-  '/acquisitions/$acquisitionId/grids/$gridId/squares': typeof AcquisitionsAcquisitionIdGridsGridIdSquaresRoute
+  '/acquisitions/$acquisitionId/grids/$gridId/squares': typeof AcquisitionsAcquisitionIdGridsGridIdSquaresRouteWithChildren
   '/acquisitions/$acquisitionId/grids/$gridId/workspace': typeof AcquisitionsAcquisitionIdGridsGridIdWorkspaceRoute
   '/acquisitions/$acquisitionId/grids/$gridId/': typeof AcquisitionsAcquisitionIdGridsGridIdIndexRoute
+  '/acquisitions/$acquisitionId/grids/$gridId/squares/gallery': typeof AcquisitionsAcquisitionIdGridsGridIdSquaresGalleryRoute
   '/acquisitions/$acquisitionId/grids/$gridId/squares/$squareId': typeof AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdRouteWithChildren
+  '/acquisitions/$acquisitionId/grids/$gridId/squares/': typeof AcquisitionsAcquisitionIdGridsGridIdSquaresIndexRoute
   '/acquisitions/$acquisitionId/grids/$gridId/squares/$squareId/predictions': typeof AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdPredictionsRoute
   '/acquisitions/$acquisitionId/grids/$gridId/squares/$squareId/': typeof AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdIndexRoute
   '/acquisitions/$acquisitionId/grids/$gridId/squares/$squareId/holes/$holeId': typeof AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdHolesHoleIdRoute
@@ -166,9 +182,10 @@ export interface FileRoutesByTo {
   '/acquisitions/$acquisitionId': typeof AcquisitionsAcquisitionIdIndexRoute
   '/acquisitions/$acquisitionId/grids/$gridId/atlas': typeof AcquisitionsAcquisitionIdGridsGridIdAtlasRoute
   '/acquisitions/$acquisitionId/grids/$gridId/predictions': typeof AcquisitionsAcquisitionIdGridsGridIdPredictionsRoute
-  '/acquisitions/$acquisitionId/grids/$gridId/squares': typeof AcquisitionsAcquisitionIdGridsGridIdSquaresRoute
   '/acquisitions/$acquisitionId/grids/$gridId/workspace': typeof AcquisitionsAcquisitionIdGridsGridIdWorkspaceRoute
   '/acquisitions/$acquisitionId/grids/$gridId': typeof AcquisitionsAcquisitionIdGridsGridIdIndexRoute
+  '/acquisitions/$acquisitionId/grids/$gridId/squares/gallery': typeof AcquisitionsAcquisitionIdGridsGridIdSquaresGalleryRoute
+  '/acquisitions/$acquisitionId/grids/$gridId/squares': typeof AcquisitionsAcquisitionIdGridsGridIdSquaresIndexRoute
   '/acquisitions/$acquisitionId/grids/$gridId/squares/$squareId/predictions': typeof AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdPredictionsRoute
   '/acquisitions/$acquisitionId/grids/$gridId/squares/$squareId': typeof AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdIndexRoute
   '/acquisitions/$acquisitionId/grids/$gridId/squares/$squareId/holes/$holeId': typeof AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdHolesHoleIdRoute
@@ -186,10 +203,12 @@ export interface FileRoutesById {
   '/acquisitions/$acquisitionId/grids/$gridId': typeof AcquisitionsAcquisitionIdGridsGridIdRouteWithChildren
   '/acquisitions/$acquisitionId/grids/$gridId/atlas': typeof AcquisitionsAcquisitionIdGridsGridIdAtlasRoute
   '/acquisitions/$acquisitionId/grids/$gridId/predictions': typeof AcquisitionsAcquisitionIdGridsGridIdPredictionsRoute
-  '/acquisitions/$acquisitionId/grids/$gridId/squares': typeof AcquisitionsAcquisitionIdGridsGridIdSquaresRoute
+  '/acquisitions/$acquisitionId/grids/$gridId/squares': typeof AcquisitionsAcquisitionIdGridsGridIdSquaresRouteWithChildren
   '/acquisitions/$acquisitionId/grids/$gridId/workspace': typeof AcquisitionsAcquisitionIdGridsGridIdWorkspaceRoute
   '/acquisitions/$acquisitionId/grids/$gridId/': typeof AcquisitionsAcquisitionIdGridsGridIdIndexRoute
+  '/acquisitions/$acquisitionId/grids/$gridId/squares/gallery': typeof AcquisitionsAcquisitionIdGridsGridIdSquaresGalleryRoute
   '/acquisitions/$acquisitionId/grids/$gridId/squares_/$squareId': typeof AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdRouteWithChildren
+  '/acquisitions/$acquisitionId/grids/$gridId/squares/': typeof AcquisitionsAcquisitionIdGridsGridIdSquaresIndexRoute
   '/acquisitions/$acquisitionId/grids/$gridId/squares_/$squareId/predictions': typeof AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdPredictionsRoute
   '/acquisitions/$acquisitionId/grids/$gridId/squares_/$squareId/': typeof AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdIndexRoute
   '/acquisitions/$acquisitionId/grids/$gridId/squares_/$squareId/holes_/$holeId': typeof AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdHolesHoleIdRoute
@@ -211,7 +230,9 @@ export interface FileRouteTypes {
     | '/acquisitions/$acquisitionId/grids/$gridId/squares'
     | '/acquisitions/$acquisitionId/grids/$gridId/workspace'
     | '/acquisitions/$acquisitionId/grids/$gridId/'
+    | '/acquisitions/$acquisitionId/grids/$gridId/squares/gallery'
     | '/acquisitions/$acquisitionId/grids/$gridId/squares/$squareId'
+    | '/acquisitions/$acquisitionId/grids/$gridId/squares/'
     | '/acquisitions/$acquisitionId/grids/$gridId/squares/$squareId/predictions'
     | '/acquisitions/$acquisitionId/grids/$gridId/squares/$squareId/'
     | '/acquisitions/$acquisitionId/grids/$gridId/squares/$squareId/holes/$holeId'
@@ -224,9 +245,10 @@ export interface FileRouteTypes {
     | '/acquisitions/$acquisitionId'
     | '/acquisitions/$acquisitionId/grids/$gridId/atlas'
     | '/acquisitions/$acquisitionId/grids/$gridId/predictions'
-    | '/acquisitions/$acquisitionId/grids/$gridId/squares'
     | '/acquisitions/$acquisitionId/grids/$gridId/workspace'
     | '/acquisitions/$acquisitionId/grids/$gridId'
+    | '/acquisitions/$acquisitionId/grids/$gridId/squares/gallery'
+    | '/acquisitions/$acquisitionId/grids/$gridId/squares'
     | '/acquisitions/$acquisitionId/grids/$gridId/squares/$squareId/predictions'
     | '/acquisitions/$acquisitionId/grids/$gridId/squares/$squareId'
     | '/acquisitions/$acquisitionId/grids/$gridId/squares/$squareId/holes/$holeId'
@@ -246,7 +268,9 @@ export interface FileRouteTypes {
     | '/acquisitions/$acquisitionId/grids/$gridId/squares'
     | '/acquisitions/$acquisitionId/grids/$gridId/workspace'
     | '/acquisitions/$acquisitionId/grids/$gridId/'
+    | '/acquisitions/$acquisitionId/grids/$gridId/squares/gallery'
     | '/acquisitions/$acquisitionId/grids/$gridId/squares_/$squareId'
+    | '/acquisitions/$acquisitionId/grids/$gridId/squares/'
     | '/acquisitions/$acquisitionId/grids/$gridId/squares_/$squareId/predictions'
     | '/acquisitions/$acquisitionId/grids/$gridId/squares_/$squareId/'
     | '/acquisitions/$acquisitionId/grids/$gridId/squares_/$squareId/holes_/$holeId'
@@ -358,12 +382,26 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AcquisitionsAcquisitionIdGridsGridIdAtlasRouteImport
       parentRoute: typeof AcquisitionsAcquisitionIdGridsGridIdRoute
     }
+    '/acquisitions/$acquisitionId/grids/$gridId/squares/': {
+      id: '/acquisitions/$acquisitionId/grids/$gridId/squares/'
+      path: '/'
+      fullPath: '/acquisitions/$acquisitionId/grids/$gridId/squares/'
+      preLoaderRoute: typeof AcquisitionsAcquisitionIdGridsGridIdSquaresIndexRouteImport
+      parentRoute: typeof AcquisitionsAcquisitionIdGridsGridIdSquaresRoute
+    }
     '/acquisitions/$acquisitionId/grids/$gridId/squares_/$squareId': {
       id: '/acquisitions/$acquisitionId/grids/$gridId/squares_/$squareId'
       path: '/squares/$squareId'
       fullPath: '/acquisitions/$acquisitionId/grids/$gridId/squares/$squareId'
       preLoaderRoute: typeof AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdRouteImport
       parentRoute: typeof AcquisitionsAcquisitionIdGridsGridIdRoute
+    }
+    '/acquisitions/$acquisitionId/grids/$gridId/squares/gallery': {
+      id: '/acquisitions/$acquisitionId/grids/$gridId/squares/gallery'
+      path: '/gallery'
+      fullPath: '/acquisitions/$acquisitionId/grids/$gridId/squares/gallery'
+      preLoaderRoute: typeof AcquisitionsAcquisitionIdGridsGridIdSquaresGalleryRouteImport
+      parentRoute: typeof AcquisitionsAcquisitionIdGridsGridIdSquaresRoute
     }
     '/acquisitions/$acquisitionId/grids/$gridId/squares_/$squareId/': {
       id: '/acquisitions/$acquisitionId/grids/$gridId/squares_/$squareId/'
@@ -389,6 +427,24 @@ declare module '@tanstack/react-router' {
   }
 }
 
+interface AcquisitionsAcquisitionIdGridsGridIdSquaresRouteChildren {
+  AcquisitionsAcquisitionIdGridsGridIdSquaresGalleryRoute: typeof AcquisitionsAcquisitionIdGridsGridIdSquaresGalleryRoute
+  AcquisitionsAcquisitionIdGridsGridIdSquaresIndexRoute: typeof AcquisitionsAcquisitionIdGridsGridIdSquaresIndexRoute
+}
+
+const AcquisitionsAcquisitionIdGridsGridIdSquaresRouteChildren: AcquisitionsAcquisitionIdGridsGridIdSquaresRouteChildren =
+  {
+    AcquisitionsAcquisitionIdGridsGridIdSquaresGalleryRoute:
+      AcquisitionsAcquisitionIdGridsGridIdSquaresGalleryRoute,
+    AcquisitionsAcquisitionIdGridsGridIdSquaresIndexRoute:
+      AcquisitionsAcquisitionIdGridsGridIdSquaresIndexRoute,
+  }
+
+const AcquisitionsAcquisitionIdGridsGridIdSquaresRouteWithChildren =
+  AcquisitionsAcquisitionIdGridsGridIdSquaresRoute._addFileChildren(
+    AcquisitionsAcquisitionIdGridsGridIdSquaresRouteChildren,
+  )
+
 interface AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdRouteChildren {
   AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdPredictionsRoute: typeof AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdPredictionsRoute
   AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdIndexRoute: typeof AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdIndexRoute
@@ -413,7 +469,7 @@ const AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdRouteWithChildren =
 interface AcquisitionsAcquisitionIdGridsGridIdRouteChildren {
   AcquisitionsAcquisitionIdGridsGridIdAtlasRoute: typeof AcquisitionsAcquisitionIdGridsGridIdAtlasRoute
   AcquisitionsAcquisitionIdGridsGridIdPredictionsRoute: typeof AcquisitionsAcquisitionIdGridsGridIdPredictionsRoute
-  AcquisitionsAcquisitionIdGridsGridIdSquaresRoute: typeof AcquisitionsAcquisitionIdGridsGridIdSquaresRoute
+  AcquisitionsAcquisitionIdGridsGridIdSquaresRoute: typeof AcquisitionsAcquisitionIdGridsGridIdSquaresRouteWithChildren
   AcquisitionsAcquisitionIdGridsGridIdWorkspaceRoute: typeof AcquisitionsAcquisitionIdGridsGridIdWorkspaceRoute
   AcquisitionsAcquisitionIdGridsGridIdIndexRoute: typeof AcquisitionsAcquisitionIdGridsGridIdIndexRoute
   AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdRoute: typeof AcquisitionsAcquisitionIdGridsGridIdSquaresSquareIdRouteWithChildren
@@ -426,7 +482,7 @@ const AcquisitionsAcquisitionIdGridsGridIdRouteChildren: AcquisitionsAcquisition
     AcquisitionsAcquisitionIdGridsGridIdPredictionsRoute:
       AcquisitionsAcquisitionIdGridsGridIdPredictionsRoute,
     AcquisitionsAcquisitionIdGridsGridIdSquaresRoute:
-      AcquisitionsAcquisitionIdGridsGridIdSquaresRoute,
+      AcquisitionsAcquisitionIdGridsGridIdSquaresRouteWithChildren,
     AcquisitionsAcquisitionIdGridsGridIdWorkspaceRoute:
       AcquisitionsAcquisitionIdGridsGridIdWorkspaceRoute,
     AcquisitionsAcquisitionIdGridsGridIdIndexRoute:

--- a/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.squares.gallery.tsx
+++ b/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.squares.gallery.tsx
@@ -1,0 +1,337 @@
+import {
+  Box,
+  ButtonBase,
+  Checkbox,
+  CircularProgress,
+  FormControlLabel,
+  MenuItem,
+  Pagination,
+  Select,
+  Typography,
+} from '@mui/material'
+import type { GridSquareResponse } from '@smartem/api'
+import {
+  useGetGridAtlasImageGridsGridUuidAtlasImageGet as useAtlasCrop,
+  useGetGridGridsquaresGridsGridUuidGridsquaresGet,
+} from '@smartem/api'
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { useCallback, useMemo, useState } from 'react'
+import { useBlobObjectUrl } from '~/hooks/useBlobObjectUrl'
+import { gray, statusColors } from '~/theme'
+
+const COLUMN_OPTIONS = [2, 3, 4, 5]
+// Page size is capped: every tile is a heavy server-side atlas crop, so a larger page means a larger
+// simultaneous crop fan-out against the backend.
+const PAGE_SIZE_OPTIONS = [9, 18, 36]
+
+// Per-user persisted numeric preference, validated against an allow-list so a stale or garbage
+// localStorage value can't wedge the layout.
+function usePersistedNumber(
+  key: string,
+  fallback: number,
+  allowed: number[]
+): [number, (n: number) => void] {
+  const [value, setValue] = useState<number>(() => {
+    const raw = typeof window !== 'undefined' ? window.localStorage.getItem(key) : null
+    const n = raw != null ? Number(raw) : Number.NaN
+    return allowed.includes(n) ? n : fallback
+  })
+  const set = useCallback(
+    (n: number) => {
+      setValue(n)
+      try {
+        window.localStorage.setItem(key, String(n))
+      } catch {
+        // ignore storage failures (private mode, quota) - the in-memory value still applies
+      }
+    },
+    [key]
+  )
+  return [value, set]
+}
+
+export const Route = createFileRoute('/acquisitions/$acquisitionId/grids/$gridId/squares/gallery')({
+  component: SquareGalleryView,
+})
+
+// Physical area for the size sort; squares missing dimensions sort last (negative area).
+function squareArea(s: GridSquareResponse): number {
+  if (s.size_width == null || s.size_height == null) return -1
+  return s.size_width * s.size_height
+}
+
+function SquareGalleryView() {
+  const { acquisitionId, gridId } = Route.useParams()
+  const navigate = useNavigate()
+  const {
+    data: squares,
+    isLoading,
+    error,
+  } = useGetGridGridsquaresGridsGridUuidGridsquaresGet(gridId)
+  const [page, setPage] = useState(1)
+  const [collectedOnly, setCollectedOnly] = useState(false)
+  const [columns, setColumns] = usePersistedNumber('smartem.gallery.columns', 3, COLUMN_OPTIONS)
+  const [pageSize, setPageSize] = usePersistedNumber(
+    'smartem.gallery.pageSize',
+    9,
+    PAGE_SIZE_OPTIONS
+  )
+
+  const sorted = useMemo(() => {
+    const list = (squares ?? []).filter((s) => (collectedOnly ? s.image_path != null : true))
+    return [...list].sort((a, b) => squareArea(b) - squareArea(a))
+  }, [squares, collectedOnly])
+
+  const pageCount = Math.max(1, Math.ceil(sorted.length / pageSize))
+  const currentPage = Math.min(page, pageCount)
+  const visible = sorted.slice((currentPage - 1) * pageSize, currentPage * pageSize)
+
+  if (isLoading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
+        <CircularProgress size={28} />
+      </Box>
+    )
+  }
+
+  if (error) {
+    return (
+      <Box sx={{ p: 4, textAlign: 'center' }}>
+        <Typography variant="body1" color="error">
+          Failed to load grid squares
+        </Typography>
+      </Box>
+    )
+  }
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden' }}>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 2,
+          rowGap: 1,
+          flexWrap: 'wrap',
+          px: 2,
+          py: 1,
+          borderBottom: '1px solid',
+          borderColor: 'divider',
+          flexShrink: 0,
+        }}
+      >
+        <FormControlLabel
+          control={
+            <Checkbox
+              size="small"
+              checked={collectedOnly}
+              onChange={(e) => {
+                setCollectedOnly(e.target.checked)
+                setPage(1)
+              }}
+              sx={{ p: 0.5 }}
+            />
+          }
+          label={<Typography variant="caption">Collected only</Typography>}
+          sx={{ mr: 0 }}
+        />
+        <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+          {sorted.length} squares
+        </Typography>
+        <Box sx={{ flex: 1 }} />
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+          <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+            Columns
+          </Typography>
+          {COLUMN_OPTIONS.map((c) => (
+            <ButtonBase
+              key={c}
+              onClick={() => setColumns(c)}
+              aria-label={`${c} columns`}
+              sx={{
+                minWidth: 22,
+                px: 0.75,
+                py: 0.25,
+                borderRadius: 0.5,
+                fontSize: '0.6875rem',
+                fontWeight: c === columns ? 600 : 400,
+                color: c === columns ? 'text.primary' : 'text.secondary',
+                backgroundColor: c === columns ? gray[100] : 'transparent',
+                '&:hover': { backgroundColor: gray[100] },
+              }}
+            >
+              {c}
+            </ButtonBase>
+          ))}
+        </Box>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+          <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+            Per page
+          </Typography>
+          <Select
+            size="small"
+            variant="standard"
+            value={pageSize}
+            onChange={(e) => {
+              setPageSize(Number(e.target.value))
+              setPage(1)
+            }}
+            sx={{ fontSize: '0.6875rem', '& .MuiSelect-select': { py: 0.25, pr: 2.5 } }}
+          >
+            {PAGE_SIZE_OPTIONS.map((n) => (
+              <MenuItem key={n} value={n} sx={{ fontSize: '0.75rem' }}>
+                {n}
+              </MenuItem>
+            ))}
+          </Select>
+        </Box>
+        {pageCount > 1 && (
+          <Pagination
+            size="small"
+            count={pageCount}
+            page={currentPage}
+            onChange={(_, v) => setPage(v)}
+          />
+        )}
+      </Box>
+
+      <Box sx={{ flex: 1, overflow: 'auto', p: 2 }}>
+        {visible.length === 0 ? (
+          <Box sx={{ p: 4, textAlign: 'center' }}>
+            <Typography variant="body2" color="text.secondary">
+              No grid squares to show.
+            </Typography>
+          </Box>
+        ) : (
+          <Box sx={{ display: 'grid', gridTemplateColumns: `repeat(${columns}, 1fr)`, gap: 2 }}>
+            {visible.map((sq) => (
+              <SquareThumbnail
+                key={sq.uuid}
+                gridId={gridId}
+                square={sq}
+                onClick={() =>
+                  navigate({
+                    to: '/acquisitions/$acquisitionId/grids/$gridId/squares/$squareId',
+                    params: { acquisitionId, gridId, squareId: sq.uuid },
+                  })
+                }
+              />
+            ))}
+          </Box>
+        )}
+      </Box>
+    </Box>
+  )
+}
+
+// One gallery tile: an authenticated atlas crop (object URL, like the other image views) over a
+// checkered placeholder, the square label, and a collected dot. The crop reads from the grid atlas,
+// which exists regardless of whether this square's own micrograph was collected.
+function SquareThumbnail({
+  gridId,
+  square,
+  onClick,
+}: {
+  gridId: string
+  square: GridSquareResponse
+  onClick: () => void
+}) {
+  const params = useMemo(
+    () => ({ x: square.center_x, y: square.center_y, w: square.size_width, h: square.size_height }),
+    [square.center_x, square.center_y, square.size_width, square.size_height]
+  )
+  const hasGeometry =
+    square.center_x != null &&
+    square.center_y != null &&
+    square.size_width != null &&
+    square.size_height != null
+  const { data: blob, isLoading } = useAtlasCrop(gridId, params, {
+    query: { enabled: hasGeometry },
+  })
+  const imageUrl = useBlobObjectUrl(blob as Blob | undefined)
+  const collected = square.image_path != null
+
+  return (
+    <Box
+      onClick={onClick}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') onClick()
+      }}
+      role="button"
+      tabIndex={0}
+      sx={{
+        cursor: 'pointer',
+        border: '1px solid',
+        borderColor: 'divider',
+        borderRadius: 1,
+        overflow: 'hidden',
+        backgroundColor: 'background.paper',
+        transition: 'border-color 0.1s, box-shadow 0.1s',
+        '&:hover': { borderColor: 'primary.main', boxShadow: 1 },
+      }}
+    >
+      <Box sx={{ position: 'relative', aspectRatio: '1 / 1', backgroundColor: gray[900] }}>
+        {!imageUrl && (
+          <Box
+            sx={{
+              position: 'absolute',
+              inset: 0,
+              background: `repeating-conic-gradient(${gray[200]} 0% 25%, ${gray[50]} 0% 50%) 50% / 16px 16px`,
+            }}
+          />
+        )}
+        {imageUrl && (
+          <Box
+            component="img"
+            src={imageUrl}
+            alt={`Grid square ${square.gridsquare_id}`}
+            sx={{
+              position: 'absolute',
+              inset: 0,
+              width: '100%',
+              height: '100%',
+              objectFit: 'cover',
+            }}
+          />
+        )}
+        {isLoading && hasGeometry && (
+          <Box
+            sx={{
+              position: 'absolute',
+              inset: 0,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            <CircularProgress size={20} />
+          </Box>
+        )}
+      </Box>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, px: 1, py: 0.5 }}>
+        <Typography
+          variant="caption"
+          sx={{
+            fontWeight: 500,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {square.gridsquare_id}
+        </Typography>
+        <Box sx={{ flex: 1 }} />
+        <Box
+          title={collected ? 'Collected' : 'Not collected'}
+          sx={{
+            width: 7,
+            height: 7,
+            borderRadius: '50%',
+            backgroundColor: collected ? statusColors.running : gray[300],
+            flexShrink: 0,
+          }}
+        />
+      </Box>
+    </Box>
+  )
+}

--- a/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.squares.index.tsx
+++ b/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.squares.index.tsx
@@ -1,0 +1,332 @@
+import {
+  Box,
+  CircularProgress,
+  IconButton,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TableSortLabel,
+  Typography,
+} from '@mui/material'
+import type { GridSquareStatus } from '@smartem/api'
+import {
+  useGetGridGridsquaresGridsGridUuidGridsquaresGet,
+  useGetGridsquareFoilholesGridsquaresGridsquareUuidFoilholesGet,
+} from '@smartem/api'
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { Fragment, useMemo, useState } from 'react'
+import { gray, statusColors } from '~/theme'
+
+export const Route = createFileRoute('/acquisitions/$acquisitionId/grids/$gridId/squares/')({
+  component: SquaresTable,
+})
+
+type SortField = 'defocus' | 'magnification' | 'gridsquareId'
+type SortDir = 'asc' | 'desc'
+
+function SquaresTable() {
+  const { acquisitionId, gridId } = Route.useParams()
+  const navigate = useNavigate()
+  const {
+    data: squares,
+    isLoading,
+    error,
+  } = useGetGridGridsquaresGridsGridUuidGridsquaresGet(gridId)
+
+  const [sortField, setSortField] = useState<SortField>('gridsquareId')
+  const [sortDir, setSortDir] = useState<SortDir>('asc')
+  const [expanded, setExpanded] = useState<Set<string>>(new Set())
+
+  const toggleExpanded = (uuid: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev)
+      if (next.has(uuid)) next.delete(uuid)
+      else next.add(uuid)
+      return next
+    })
+  }
+
+  const sorted = useMemo(() => {
+    const arr = [...(squares ?? [])]
+    arr.sort((a, b) => {
+      let cmp = 0
+      if (sortField === 'defocus') cmp = (a.defocus ?? 0) - (b.defocus ?? 0)
+      else if (sortField === 'magnification') cmp = (a.magnification ?? 0) - (b.magnification ?? 0)
+      else cmp = a.gridsquare_id.localeCompare(b.gridsquare_id)
+      return sortDir === 'desc' ? -cmp : cmp
+    })
+    return arr
+  }, [squares, sortField, sortDir])
+
+  const handleSort = (field: SortField) => {
+    if (field === sortField) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'))
+    } else {
+      setSortField(field)
+      setSortDir('desc')
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
+        <CircularProgress size={28} />
+      </Box>
+    )
+  }
+
+  if (error) {
+    return (
+      <Box sx={{ p: 4, textAlign: 'center' }}>
+        <Typography variant="body1" color="error">
+          Failed to load grid squares
+        </Typography>
+      </Box>
+    )
+  }
+
+  return (
+    <TableContainer sx={{ height: '100%', overflow: 'auto' }}>
+      <Table stickyHeader size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell sx={{ width: 36 }} />
+            <TableCell>
+              <TableSortLabel
+                active={sortField === 'gridsquareId'}
+                direction={sortField === 'gridsquareId' ? sortDir : 'asc'}
+                onClick={() => handleSort('gridsquareId')}
+              >
+                ID
+              </TableSortLabel>
+            </TableCell>
+            <TableCell>Status</TableCell>
+            <TableCell>Selected</TableCell>
+            <TableCell>
+              <TableSortLabel
+                active={sortField === 'defocus'}
+                direction={sortField === 'defocus' ? sortDir : 'desc'}
+                onClick={() => handleSort('defocus')}
+              >
+                Defocus
+              </TableSortLabel>
+            </TableCell>
+            <TableCell>
+              <TableSortLabel
+                active={sortField === 'magnification'}
+                direction={sortField === 'magnification' ? sortDir : 'desc'}
+                onClick={() => handleSort('magnification')}
+              >
+                Magnification
+              </TableSortLabel>
+            </TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {sorted.map((sq) => {
+            const isOpen = expanded.has(sq.uuid)
+            return (
+              <Fragment key={sq.uuid}>
+                <TableRow
+                  hover
+                  sx={{
+                    cursor: 'pointer',
+                    '& > td': { borderBottom: isOpen ? 'none' : undefined },
+                  }}
+                  onClick={() =>
+                    navigate({
+                      to: '/acquisitions/$acquisitionId/grids/$gridId/squares/$squareId',
+                      params: { acquisitionId, gridId, squareId: sq.uuid },
+                    })
+                  }
+                >
+                  <TableCell sx={{ width: 36, pr: 0 }}>
+                    <IconButton
+                      size="small"
+                      aria-label={isOpen ? 'Collapse foilholes' : 'Expand foilholes'}
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        toggleExpanded(sq.uuid)
+                      }}
+                      sx={{ p: 0.25 }}
+                    >
+                      <Chevron open={isOpen} />
+                    </IconButton>
+                  </TableCell>
+                  <TableCell>
+                    <Typography variant="body2" fontWeight={500}>
+                      {sq.gridsquare_id}
+                    </Typography>
+                  </TableCell>
+                  <TableCell>
+                    <StatusLabel status={sq.status} />
+                  </TableCell>
+                  <TableCell>
+                    <Typography
+                      variant="body2"
+                      color={sq.selected ? 'text.primary' : 'text.disabled'}
+                    >
+                      {sq.selected ? 'Yes' : 'No'}
+                    </Typography>
+                  </TableCell>
+                  <TableCell>
+                    <Typography
+                      variant="body2"
+                      sx={{ fontVariantNumeric: 'tabular-nums', color: 'text.secondary' }}
+                    >
+                      {sq.defocus != null ? `${sq.defocus} um` : '--'}
+                    </Typography>
+                  </TableCell>
+                  <TableCell>
+                    <Typography
+                      variant="body2"
+                      sx={{ fontVariantNumeric: 'tabular-nums', color: 'text.secondary' }}
+                    >
+                      {sq.magnification != null ? `${(sq.magnification / 1000).toFixed(0)}k` : '--'}
+                    </Typography>
+                  </TableCell>
+                </TableRow>
+                {isOpen && (
+                  <TableRow>
+                    <TableCell colSpan={6} sx={{ py: 0, backgroundColor: gray[50] }}>
+                      <FoilholeSubTable squareUuid={sq.uuid} />
+                    </TableCell>
+                  </TableRow>
+                )}
+              </Fragment>
+            )
+          })}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  )
+}
+
+// Lazily loaded when a square row is expanded: its foilholes with a weighted aggregate
+// (mean predicted quality) and a per-foilhole table sortable by quality.
+function FoilholeSubTable({ squareUuid }: { squareUuid: string }) {
+  const { data: foilholes, isLoading } =
+    useGetGridsquareFoilholesGridsquaresGridsquareUuidFoilholesGet(squareUuid)
+  const [dir, setDir] = useState<SortDir>('desc')
+
+  const rows = useMemo(() => {
+    const arr = [...(foilholes ?? [])]
+    arr.sort((a, b) => {
+      const cmp = (a.quality ?? 0) - (b.quality ?? 0)
+      return dir === 'desc' ? -cmp : cmp
+    })
+    return arr
+  }, [foilholes, dir])
+
+  if (isLoading) {
+    return (
+      <Box sx={{ p: 1.5 }}>
+        <CircularProgress size={16} />
+      </Box>
+    )
+  }
+
+  if (rows.length === 0) {
+    return (
+      <Typography variant="caption" sx={{ color: 'text.disabled', p: 1.5, display: 'block' }}>
+        No foilholes recorded for this square.
+      </Typography>
+    )
+  }
+
+  const qualities = rows.map((r) => r.quality).filter((q): q is number => q != null)
+  const avg = qualities.length > 0 ? qualities.reduce((s, q) => s + q, 0) / qualities.length : null
+
+  return (
+    <Box sx={{ pl: 6, pr: 2, py: 1 }}>
+      <Typography variant="caption" sx={{ fontWeight: 600 }}>
+        {rows.length} foilholes
+        {avg != null ? ` · weighted quality ${Math.round(avg * 100)}%` : ''}
+      </Typography>
+      <Table size="small" sx={{ mt: 0.5, maxWidth: 460 }}>
+        <TableHead>
+          <TableRow>
+            <TableCell sx={{ py: 0.25 }}>Foilhole</TableCell>
+            <TableCell sx={{ py: 0.25 }}>
+              <TableSortLabel
+                active
+                direction={dir}
+                onClick={() => setDir((d) => (d === 'asc' ? 'desc' : 'asc'))}
+              >
+                Quality
+              </TableSortLabel>
+            </TableCell>
+            <TableCell sx={{ py: 0.25 }}>Status</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {rows.map((fh) => (
+            <TableRow key={fh.uuid}>
+              <TableCell sx={{ py: 0.25 }}>
+                <Typography variant="caption">
+                  {fh.foilhole_id}
+                  {fh.is_near_grid_bar ? ' · grid bar' : ''}
+                </Typography>
+              </TableCell>
+              <TableCell sx={{ py: 0.25 }}>
+                <Typography variant="caption" sx={{ fontVariantNumeric: 'tabular-nums' }}>
+                  {fh.quality != null ? `${Math.round(fh.quality * 100)}%` : '--'}
+                </Typography>
+              </TableCell>
+              <TableCell sx={{ py: 0.25 }}>
+                <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                  {fh.status}
+                </Typography>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </Box>
+  )
+}
+
+function Chevron({ open }: { open: boolean }) {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 16 16"
+      fill="currentColor"
+      role="img"
+      aria-hidden="true"
+      style={{ transform: open ? 'rotate(90deg)' : 'none', transition: 'transform 0.12s' }}
+    >
+      <path d="M6 4l4 4-4 4V4z" />
+    </svg>
+  )
+}
+
+const statusColorMap: Record<GridSquareStatus, string> = {
+  none: statusColors.offline,
+  'all foil holes registered': statusColors.idle,
+  'foil holes decision started': statusColors.paused,
+  'foil holes decision completed': statusColors.running,
+}
+
+const statusLabelMap: Record<GridSquareStatus, string> = {
+  none: 'None',
+  'all foil holes registered': 'Holes registered',
+  'foil holes decision started': 'Deciding',
+  'foil holes decision completed': 'Completed',
+}
+
+function StatusLabel({ status }: { status: GridSquareStatus | null }) {
+  const s = status ?? 'none'
+  return (
+    <Typography
+      variant="caption"
+      sx={{ color: statusColorMap[s], fontWeight: 500, fontSize: '0.6875rem' }}
+    >
+      {statusLabelMap[s]}
+    </Typography>
+  )
+}

--- a/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.squares.tsx
+++ b/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.squares.tsx
@@ -1,332 +1,62 @@
-import {
-  Box,
-  CircularProgress,
-  IconButton,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  TableSortLabel,
-  Typography,
-} from '@mui/material'
-import type { GridSquareStatus } from '@smartem/api'
-import {
-  useGetGridGridsquaresGridsGridUuidGridsquaresGet,
-  useGetGridsquareFoilholesGridsquaresGridsquareUuidFoilholesGet,
-} from '@smartem/api'
-import { createFileRoute, useNavigate } from '@tanstack/react-router'
-import { Fragment, useMemo, useState } from 'react'
-import { gray, statusColors } from '~/theme'
+import { Box } from '@mui/material'
+import { createFileRoute, Link, Outlet, useRouterState } from '@tanstack/react-router'
+import { gray } from '~/theme'
 
 export const Route = createFileRoute('/acquisitions/$acquisitionId/grids/$gridId/squares')({
-  component: SquaresTable,
+  component: SquaresLayout,
 })
 
-type SortField = 'defocus' | 'magnification' | 'gridsquareId'
-type SortDir = 'asc' | 'desc'
-
-function SquaresTable() {
+// Two lenses on the same grid-square collection: the sortable, expandable Table (index) and the
+// thumbnail Gallery. The square detail view (squares_/$squareId) is intentionally un-nested, so this
+// sub-switch only frames the two collection views.
+function SquaresLayout() {
   const { acquisitionId, gridId } = Route.useParams()
-  const navigate = useNavigate()
-  const {
-    data: squares,
-    isLoading,
-    error,
-  } = useGetGridGridsquaresGridsGridUuidGridsquaresGet(gridId)
+  const pathname = useRouterState({ select: (s) => s.location.pathname })
+  const onGallery = pathname.endsWith('/gallery')
 
-  const [sortField, setSortField] = useState<SortField>('gridsquareId')
-  const [sortDir, setSortDir] = useState<SortDir>('asc')
-  const [expanded, setExpanded] = useState<Set<string>>(new Set())
-
-  const toggleExpanded = (uuid: string) => {
-    setExpanded((prev) => {
-      const next = new Set(prev)
-      if (next.has(uuid)) next.delete(uuid)
-      else next.add(uuid)
-      return next
-    })
-  }
-
-  const sorted = useMemo(() => {
-    const arr = [...(squares ?? [])]
-    arr.sort((a, b) => {
-      let cmp = 0
-      if (sortField === 'defocus') cmp = (a.defocus ?? 0) - (b.defocus ?? 0)
-      else if (sortField === 'magnification') cmp = (a.magnification ?? 0) - (b.magnification ?? 0)
-      else cmp = a.gridsquare_id.localeCompare(b.gridsquare_id)
-      return sortDir === 'desc' ? -cmp : cmp
-    })
-    return arr
-  }, [squares, sortField, sortDir])
-
-  const handleSort = (field: SortField) => {
-    if (field === sortField) {
-      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'))
-    } else {
-      setSortField(field)
-      setSortDir('desc')
-    }
-  }
-
-  if (isLoading) {
-    return (
-      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
-        <CircularProgress size={28} />
-      </Box>
-    )
-  }
-
-  if (error) {
-    return (
-      <Box sx={{ p: 4, textAlign: 'center' }}>
-        <Typography variant="body1" color="error">
-          Failed to load grid squares
-        </Typography>
-      </Box>
-    )
-  }
+  const tabSx = (active: boolean) => ({
+    px: 1.25,
+    py: 0.5,
+    fontSize: '0.8125rem',
+    fontWeight: active ? 600 : 400,
+    color: active ? 'text.primary' : 'text.secondary',
+    textDecoration: 'none',
+    borderBottom: '2px solid',
+    borderColor: active ? 'primary.main' : 'transparent',
+    '&:hover': { color: 'text.primary' },
+  })
 
   return (
-    <TableContainer sx={{ height: '100%', overflow: 'auto' }}>
-      <Table stickyHeader size="small">
-        <TableHead>
-          <TableRow>
-            <TableCell sx={{ width: 36 }} />
-            <TableCell>
-              <TableSortLabel
-                active={sortField === 'gridsquareId'}
-                direction={sortField === 'gridsquareId' ? sortDir : 'asc'}
-                onClick={() => handleSort('gridsquareId')}
-              >
-                ID
-              </TableSortLabel>
-            </TableCell>
-            <TableCell>Status</TableCell>
-            <TableCell>Selected</TableCell>
-            <TableCell>
-              <TableSortLabel
-                active={sortField === 'defocus'}
-                direction={sortField === 'defocus' ? sortDir : 'desc'}
-                onClick={() => handleSort('defocus')}
-              >
-                Defocus
-              </TableSortLabel>
-            </TableCell>
-            <TableCell>
-              <TableSortLabel
-                active={sortField === 'magnification'}
-                direction={sortField === 'magnification' ? sortDir : 'desc'}
-                onClick={() => handleSort('magnification')}
-              >
-                Magnification
-              </TableSortLabel>
-            </TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {sorted.map((sq) => {
-            const isOpen = expanded.has(sq.uuid)
-            return (
-              <Fragment key={sq.uuid}>
-                <TableRow
-                  hover
-                  sx={{
-                    cursor: 'pointer',
-                    '& > td': { borderBottom: isOpen ? 'none' : undefined },
-                  }}
-                  onClick={() =>
-                    navigate({
-                      to: '/acquisitions/$acquisitionId/grids/$gridId/squares/$squareId',
-                      params: { acquisitionId, gridId, squareId: sq.uuid },
-                    })
-                  }
-                >
-                  <TableCell sx={{ width: 36, pr: 0 }}>
-                    <IconButton
-                      size="small"
-                      aria-label={isOpen ? 'Collapse foilholes' : 'Expand foilholes'}
-                      onClick={(e) => {
-                        e.stopPropagation()
-                        toggleExpanded(sq.uuid)
-                      }}
-                      sx={{ p: 0.25 }}
-                    >
-                      <Chevron open={isOpen} />
-                    </IconButton>
-                  </TableCell>
-                  <TableCell>
-                    <Typography variant="body2" fontWeight={500}>
-                      {sq.gridsquare_id}
-                    </Typography>
-                  </TableCell>
-                  <TableCell>
-                    <StatusLabel status={sq.status} />
-                  </TableCell>
-                  <TableCell>
-                    <Typography
-                      variant="body2"
-                      color={sq.selected ? 'text.primary' : 'text.disabled'}
-                    >
-                      {sq.selected ? 'Yes' : 'No'}
-                    </Typography>
-                  </TableCell>
-                  <TableCell>
-                    <Typography
-                      variant="body2"
-                      sx={{ fontVariantNumeric: 'tabular-nums', color: 'text.secondary' }}
-                    >
-                      {sq.defocus != null ? `${sq.defocus} um` : '--'}
-                    </Typography>
-                  </TableCell>
-                  <TableCell>
-                    <Typography
-                      variant="body2"
-                      sx={{ fontVariantNumeric: 'tabular-nums', color: 'text.secondary' }}
-                    >
-                      {sq.magnification != null ? `${(sq.magnification / 1000).toFixed(0)}k` : '--'}
-                    </Typography>
-                  </TableCell>
-                </TableRow>
-                {isOpen && (
-                  <TableRow>
-                    <TableCell colSpan={6} sx={{ py: 0, backgroundColor: gray[50] }}>
-                      <FoilholeSubTable squareUuid={sq.uuid} />
-                    </TableCell>
-                  </TableRow>
-                )}
-              </Fragment>
-            )
-          })}
-        </TableBody>
-      </Table>
-    </TableContainer>
-  )
-}
-
-// Lazily loaded when a square row is expanded: its foilholes with a weighted aggregate
-// (mean predicted quality) and a per-foilhole table sortable by quality.
-function FoilholeSubTable({ squareUuid }: { squareUuid: string }) {
-  const { data: foilholes, isLoading } =
-    useGetGridsquareFoilholesGridsquaresGridsquareUuidFoilholesGet(squareUuid)
-  const [dir, setDir] = useState<SortDir>('desc')
-
-  const rows = useMemo(() => {
-    const arr = [...(foilholes ?? [])]
-    arr.sort((a, b) => {
-      const cmp = (a.quality ?? 0) - (b.quality ?? 0)
-      return dir === 'desc' ? -cmp : cmp
-    })
-    return arr
-  }, [foilholes, dir])
-
-  if (isLoading) {
-    return (
-      <Box sx={{ p: 1.5 }}>
-        <CircularProgress size={16} />
+    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden' }}>
+      <Box
+        sx={{
+          display: 'flex',
+          gap: 0.5,
+          px: 2,
+          borderBottom: '1px solid',
+          borderColor: 'divider',
+          backgroundColor: gray[50],
+          flexShrink: 0,
+        }}
+      >
+        <Link
+          to="/acquisitions/$acquisitionId/grids/$gridId/squares"
+          params={{ acquisitionId, gridId }}
+          style={{ textDecoration: 'none' }}
+        >
+          <Box sx={tabSx(!onGallery)}>Table</Box>
+        </Link>
+        <Link
+          to="/acquisitions/$acquisitionId/grids/$gridId/squares/gallery"
+          params={{ acquisitionId, gridId }}
+          style={{ textDecoration: 'none' }}
+        >
+          <Box sx={tabSx(onGallery)}>Gallery</Box>
+        </Link>
       </Box>
-    )
-  }
-
-  if (rows.length === 0) {
-    return (
-      <Typography variant="caption" sx={{ color: 'text.disabled', p: 1.5, display: 'block' }}>
-        No foilholes recorded for this square.
-      </Typography>
-    )
-  }
-
-  const qualities = rows.map((r) => r.quality).filter((q): q is number => q != null)
-  const avg = qualities.length > 0 ? qualities.reduce((s, q) => s + q, 0) / qualities.length : null
-
-  return (
-    <Box sx={{ pl: 6, pr: 2, py: 1 }}>
-      <Typography variant="caption" sx={{ fontWeight: 600 }}>
-        {rows.length} foilholes
-        {avg != null ? ` · weighted quality ${Math.round(avg * 100)}%` : ''}
-      </Typography>
-      <Table size="small" sx={{ mt: 0.5, maxWidth: 460 }}>
-        <TableHead>
-          <TableRow>
-            <TableCell sx={{ py: 0.25 }}>Foilhole</TableCell>
-            <TableCell sx={{ py: 0.25 }}>
-              <TableSortLabel
-                active
-                direction={dir}
-                onClick={() => setDir((d) => (d === 'asc' ? 'desc' : 'asc'))}
-              >
-                Quality
-              </TableSortLabel>
-            </TableCell>
-            <TableCell sx={{ py: 0.25 }}>Status</TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {rows.map((fh) => (
-            <TableRow key={fh.uuid}>
-              <TableCell sx={{ py: 0.25 }}>
-                <Typography variant="caption">
-                  {fh.foilhole_id}
-                  {fh.is_near_grid_bar ? ' · grid bar' : ''}
-                </Typography>
-              </TableCell>
-              <TableCell sx={{ py: 0.25 }}>
-                <Typography variant="caption" sx={{ fontVariantNumeric: 'tabular-nums' }}>
-                  {fh.quality != null ? `${Math.round(fh.quality * 100)}%` : '--'}
-                </Typography>
-              </TableCell>
-              <TableCell sx={{ py: 0.25 }}>
-                <Typography variant="caption" sx={{ color: 'text.secondary' }}>
-                  {fh.status}
-                </Typography>
-              </TableCell>
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table>
+      <Box sx={{ flex: 1, overflow: 'hidden' }}>
+        <Outlet />
+      </Box>
     </Box>
-  )
-}
-
-function Chevron({ open }: { open: boolean }) {
-  return (
-    <svg
-      width="14"
-      height="14"
-      viewBox="0 0 16 16"
-      fill="currentColor"
-      role="img"
-      aria-hidden="true"
-      style={{ transform: open ? 'rotate(90deg)' : 'none', transition: 'transform 0.12s' }}
-    >
-      <path d="M6 4l4 4-4 4V4z" />
-    </svg>
-  )
-}
-
-const statusColorMap: Record<GridSquareStatus, string> = {
-  none: statusColors.offline,
-  'all foil holes registered': statusColors.idle,
-  'foil holes decision started': statusColors.paused,
-  'foil holes decision completed': statusColors.running,
-}
-
-const statusLabelMap: Record<GridSquareStatus, string> = {
-  none: 'None',
-  'all foil holes registered': 'Holes registered',
-  'foil holes decision started': 'Deciding',
-  'foil holes decision completed': 'Completed',
-}
-
-function StatusLabel({ status }: { status: GridSquareStatus | null }) {
-  const s = status ?? 'none'
-  return (
-    <Typography
-      variant="caption"
-      sx={{ color: statusColorMap[s], fontWeight: 500, fontSize: '0.6875rem' }}
-    >
-      {statusLabelMap[s]}
-    </Typography>
   )
 }

--- a/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.squares_.$squareId.index.tsx
+++ b/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.squares_.$squareId.index.tsx
@@ -1,6 +1,16 @@
+import { Box, IconButton, Tooltip } from '@mui/material'
+import {
+  getGetSquareLatentRepPredictionModelPredictionModelNameGridsquareGridsquareUuidLatentRepresentationGetQueryOptions as squareLatentRepQueryOptions,
+  useGetPredictionModelsPredictionModelsGet,
+} from '@smartem/api'
+import { useQueries } from '@tanstack/react-query'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { useMemo, useState } from 'react'
+import { type LatentSpaceItem, LatentSpacePanel } from '~/components/spatial/LatentSpacePanel'
 import { SquareMap } from '~/components/spatial/SquareMap'
+import { latentResponsesToCoordsByFoilhole } from '~/data/api-adapters'
 import { useSquareMapData } from '~/hooks/useSquareMapData'
+import { gray } from '~/theme'
 
 export const Route = createFileRoute(
   '/acquisitions/$acquisitionId/grids/$gridId/squares_/$squareId/'
@@ -23,23 +33,122 @@ function SquareIndexView() {
     suggestedHoleIds,
   } = useSquareMapData(squareId)
 
+  // Fan out one latent-rep query per model, scoped to this gridsquare. Mirrors the atlas, which does
+  // the same at the grid level; React Query dedupes the models call with the one inside useSquareMapData.
+  const { data: modelResponses } = useGetPredictionModelsPredictionModelsGet()
+  const models = useMemo(() => modelResponses ?? [], [modelResponses])
+  const latentResults = useQueries({
+    queries: models.map((m) => squareLatentRepQueryOptions(m.name, squareId)),
+  })
+
+  // Lacking a model-type distinction in the API, use the first model that returns foilhole coordinates.
+  const latentByFoilhole = useMemo(() => {
+    for (const result of latentResults) {
+      if (result?.data && result.data.length > 0) {
+        const map = latentResponsesToCoordsByFoilhole(result.data)
+        if (map.size > 0) return map
+      }
+    }
+    return null
+  }, [latentResults])
+
+  const latentItems = useMemo<LatentSpaceItem[]>(() => {
+    if (!latentByFoilhole) return []
+    const lookup = latentByFoilhole
+    return foilholes.flatMap((fh) => {
+      const latent = lookup.get(fh.uuid)
+      if (!latent) return []
+      return [{ id: fh.uuid, label: fh.foilholeId, latent, predictionValue: fh.quality }]
+    })
+  }, [foilholes, latentByFoilhole])
+
+  // Hover is owned here so the map and the latent scatter cross-highlight the same foilhole.
+  const [showLatent, setShowLatent] = useState(false)
+  const [hoveredId, setHoveredId] = useState<string | null>(null)
+
+  const openHole = (holeUuid: string) => {
+    navigate({
+      to: '/acquisitions/$acquisitionId/grids/$gridId/squares/$squareId/holes/$holeId',
+      params: { acquisitionId, gridId, squareId, holeId: holeUuid },
+    })
+  }
+
   return (
-    <SquareMap
-      foilholes={foilholes}
-      squareLabel={squareLabel}
-      imageUrl={imageUrl}
-      imageLoading={imageLoading}
-      imageWidth={imageWidth}
-      imageHeight={imageHeight}
-      predictionLayers={predictionLayers}
-      predictionValues={predictionValues}
-      suggestedHoleIds={suggestedHoleIds}
-      onFoilholeClick={(holeUuid) => {
-        navigate({
-          to: '/acquisitions/$acquisitionId/grids/$gridId/squares/$squareId/holes/$holeId',
-          params: { acquisitionId, gridId, squareId, holeId: holeUuid },
-        })
-      }}
-    />
+    <Box sx={{ display: 'flex', height: '100%', overflow: 'hidden' }}>
+      <Box sx={{ flex: 1, overflow: 'hidden', minWidth: 0, position: 'relative' }}>
+        <SquareMap
+          foilholes={foilholes}
+          squareLabel={squareLabel}
+          imageUrl={imageUrl}
+          imageLoading={imageLoading}
+          imageWidth={imageWidth}
+          imageHeight={imageHeight}
+          predictionLayers={predictionLayers}
+          predictionValues={predictionValues}
+          suggestedHoleIds={suggestedHoleIds}
+          onFoilholeClick={openHole}
+          hoveredId={hoveredId}
+          onHoveredIdChange={setHoveredId}
+        />
+
+        {/* Open latent space - floats over the map, top-right, only when there are coordinates to show. */}
+        {!showLatent && latentItems.length > 0 && (
+          <Tooltip title="Show latent space" placement="left">
+            <IconButton
+              onClick={() => setShowLatent(true)}
+              size="small"
+              sx={{
+                position: 'absolute',
+                right: 12,
+                top: 12,
+                zIndex: 5,
+                backgroundColor: '#ffffff',
+                border: '1px solid',
+                borderColor: 'divider',
+                '&:hover': { backgroundColor: gray[100] },
+              }}
+            >
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 16 16"
+                fill="none"
+                role="img"
+                aria-label="Scatter plot"
+              >
+                <circle cx="4" cy="12" r="2" fill="#5878a3" />
+                <circle cx="7" cy="5" r="2" fill="#e59344" />
+                <circle cx="12" cy="9" r="2" fill="#6ba059" />
+                <circle cx="10" cy="3" r="1.5" fill="#d1605e" />
+                <circle cx="3" cy="7" r="1.5" fill="#a77c9f" />
+              </svg>
+            </IconButton>
+          </Tooltip>
+        )}
+      </Box>
+
+      {/* Latent-space pane: a foilhole scatter coloured by cluster, sharing the hovered foilhole with the
+          map. Clicking a point opens that foilhole, matching a click on the map. */}
+      {showLatent && (
+        <Box
+          sx={{
+            flexShrink: 0,
+            width: '50%',
+            minWidth: 0,
+            borderLeft: '1px solid',
+            borderColor: 'divider',
+            overflow: 'hidden',
+          }}
+        >
+          <LatentSpacePanel
+            items={latentItems}
+            selectedId={hoveredId}
+            onItemClick={openHole}
+            onItemHover={setHoveredId}
+            onClose={() => setShowLatent(false)}
+          />
+        </Box>
+      )}
+    </Box>
   )
 }


### PR DESCRIPTION
## Summary

Closes the two **functional** legacy-parity regressions from the #132 audit (A1, A2), so the legacy frontend is two items closer to retirement.

### A1 — Foil-hole latent-space panel on the square view
The square detail **Map** now offers a latent-space scatter of foil holes (floating "Show latent space" button, top-right), mirroring the existing atlas panel. The map and the scatter **cross-highlight** the same foil hole on hover; clicking a scatter point opens that foil hole.

- New foilhole-keyed latent adapter (`latentResponsesToCoordsByFoilhole`); the route fetches per-model `/prediction_model/{m}/gridsquare/{id}/latent_representation` and picks the first model returning coordinates.
- `SquareMap` gains **optional controlled-hover props**; it stays uncontrolled when they are absent, so the atlas-embedded preview panel and hole navigation are unchanged. The button is gated on latent points actually existing.

### A2 — Grid-square image gallery (Table/Gallery toggle under Squares)
Restores the legacy thumbnail gallery as a **second lens on the same collection**. The Squares route becomes a thin layout with a `Table | Gallery` sub-switch:
- **Table** — the existing sortable, expandable table (now the index child), unchanged.
- **Gallery** — a thumbnail grid of authenticated `atlas_image` crops (object-URL pattern, like the other image views), with a **collected-only** filter and size sort. Clicking a tile opens the square. The Squares top tab stays active on the gallery sub-route.

**Gallery layout is user-configurable** from the toolbar — **Columns 2–5** and **Per page 9/18/36** (page size capped to bound the per-tile crop fan-out against the backend) — persisted per user in `localStorage`.

## Verification
- `tsc`, Biome (66 files), and the production build are clean; lefthook pre-commit/pre-push passed.
- **Mock mode (MSW):** gallery sub-switch, tiles, filter, active-tab, navigation, and the latent panel component all render with zero console errors; gallery column/page-size controls verified end-to-end (re-layout + localStorage persistence across reload).
- **Real backend (dev k3s):** the restructured table renders live data; the gallery toolbar controls were verified live.

## Known limitation (environmental, not in this PR)
Against the current dev backend the **image and latent visuals render placeholders/empty app-wide**: the prod dump contains no `latent_representation` data (the existing atlas latent panel is equally empty), and the grids' atlas JPEGs are not present on disk (`atlas_image` → `FileNotFoundError`, the tracked DB-path-vs-on-disk gap). Live validation of populated imagery/latent is gated on restoring matching image + latent data, independent of this change.

Part of #132 (items A1, A2).
