### PR TITLE
feat(smartem): as-of-time slider on the foilhole quality histogram (parity #132 A3)

### DIFF
--- a/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.squares_.$squareId.predictions.tsx
+++ b/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.squares_.$squareId.predictions.tsx
@@ -1,4 +1,4 @@
-import { Box, ButtonBase, Typography } from '@mui/material'
+import { Box, ButtonBase, Slider, Typography } from '@mui/material'
 import {
   useGetFoilholeQualityPredictionTimeSeriesForGridsquareGridsquaresGridsquareUuidFoilholeQualityPredictionsGet as useFoilholeSeries,
   useGetGridsquareQualityPredictionTimeSeriesGridsquaresGridsquareUuidQualityPredictionsGet as useSquareSeries,
@@ -8,12 +8,32 @@ import { useMemo, useState } from 'react'
 import { gray, statusColors } from '~/theme'
 import { qualityColor } from '~/utils/heatmap'
 
+// Histogram resolution for the foilhole quality distribution. Matches the legacy view's ~20-bin
+// granularity (it used d3 bin().thresholds(19)).
+const BIN_COUNT = 20
+
+type SeriesPoint = { timestamp?: string | null; value: number }
+
 // The quality-prediction time-series endpoints are typed as metric-keyed records, but a
 // duplicate backend route can shadow them with a flat list payload (smartem-decisions#298),
 // so the runtime value may be an array. Treat any non-record value as empty so callers
 // never spread a non-iterable.
 function asRecord<V>(value: Record<string, V> | null | undefined): Record<string, V> {
   return value != null && typeof value === 'object' && !Array.isArray(value) ? value : {}
+}
+
+// The foilhole's predicted value as of time `t`: the most recent observation at or before `t`,
+// or null if the foilhole had no prediction yet (so it drops out of the distribution until it
+// first appears). Expects `series` sorted ascending by timestamp.
+function valueAsOf(series: SeriesPoint[], t: number): number | null {
+  let result: number | null = null
+  for (const p of series) {
+    const ts = p.timestamp ? Date.parse(p.timestamp) : Number.NaN
+    if (Number.isNaN(ts)) continue
+    if (ts <= t) result = p.value
+    else break
+  }
+  return result
 }
 
 export const Route = createFileRoute(
@@ -49,32 +69,8 @@ function SquarePredictionsView() {
     return arr.map((p) => p.value)
   }, [squareSeriesByMetric, metric])
 
-  // Latest value per foilhole for the selected metric -> distribution.
-  const foilholeValues = useMemo(() => {
-    const byHole = asRecord(foilholeSeriesByMetric[metric])
-    const vals: number[] = []
-    for (const series of Object.values(byHole)) {
-      if (!Array.isArray(series) || series.length === 0) continue
-      const latest = [...series].sort((a, b) =>
-        (a.timestamp ?? '').localeCompare(b.timestamp ?? '')
-      )
-      vals.push(latest[latest.length - 1].value)
-    }
-    return vals
-  }, [foilholeSeriesByMetric, metric])
-
-  const histogram = useMemo(() => {
-    const bins = Array(10).fill(0) as number[]
-    for (const v of foilholeValues) bins[Math.min(9, Math.max(0, Math.floor(v * 10)))]++
-    return bins
-  }, [foilholeValues])
-
   const squareMean =
     timePoints.length > 0 ? timePoints.reduce((s, v) => s + v, 0) / timePoints.length : null
-  const foilholeMean =
-    foilholeValues.length > 0
-      ? foilholeValues.reduce((s, v) => s + v, 0) / foilholeValues.length
-      : null
 
   if (metrics.length === 0) {
     return (
@@ -140,18 +136,114 @@ function SquarePredictionsView() {
             p: 2,
           }}
         >
-          <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1, mb: 1 }}>
-            <Typography variant="h6">Foilhole distribution</Typography>
-            {foilholeMean != null && (
-              <Typography variant="caption" sx={{ color: 'text.secondary' }}>
-                mean {Math.round(foilholeMean * 100)}%
-              </Typography>
-            )}
-          </Box>
-          <Histogram bins={histogram} />
+          {/* Remount per metric so the as-of slider resets to "latest" when the metric changes. */}
+          <FoilholeDistribution
+            key={metric}
+            seriesByHole={asRecord(foilholeSeriesByMetric[metric])}
+          />
         </Box>
       </Box>
     </Box>
+  )
+}
+
+// Foilhole quality distribution with an "as of time" slider: scrubbing recomputes the histogram
+// from each foilhole's most-recent value at or before the selected time, so you can watch the
+// distribution build up over the acquisition rather than only seeing the final state.
+function FoilholeDistribution({ seriesByHole }: { seriesByHole: Record<string, unknown> }) {
+  // One sorted series per foilhole that actually has points.
+  const sortedSeries = useMemo(() => {
+    const out: SeriesPoint[][] = []
+    for (const series of Object.values(seriesByHole)) {
+      if (!Array.isArray(series) || series.length === 0) continue
+      out.push(
+        [...series].sort((a, b) =>
+          (a.timestamp ?? '').localeCompare(b.timestamp ?? '')
+        ) as SeriesPoint[]
+      )
+    }
+    return out
+  }, [seriesByHole])
+
+  const { minTime, maxTime } = useMemo(() => {
+    let mn = Number.POSITIVE_INFINITY
+    let mx = Number.NEGATIVE_INFINITY
+    for (const series of sortedSeries) {
+      for (const p of series) {
+        const ts = p.timestamp ? Date.parse(p.timestamp) : Number.NaN
+        if (Number.isNaN(ts)) continue
+        if (ts < mn) mn = ts
+        if (ts > mx) mx = ts
+      }
+    }
+    return {
+      minTime: mn === Number.POSITIVE_INFINITY ? 0 : mn,
+      maxTime: mx === Number.NEGATIVE_INFINITY ? 0 : mx,
+    }
+  }, [sortedSeries])
+
+  // Slider position is a 0..1 fraction (default 1 = latest) so it stays meaningful even if the
+  // series data arrives after mount and the absolute time domain shifts.
+  const [pos, setPos] = useState(1)
+  const hasRange = maxTime > minTime
+  const selectedTime = minTime + pos * (maxTime - minTime)
+
+  const asOfValues = useMemo(() => {
+    const vals: number[] = []
+    for (const series of sortedSeries) {
+      const v = valueAsOf(series, selectedTime)
+      if (v != null) vals.push(v)
+    }
+    return vals
+  }, [sortedSeries, selectedTime])
+
+  const histogram = useMemo(() => {
+    const bins = Array(BIN_COUNT).fill(0) as number[]
+    for (const v of asOfValues)
+      bins[Math.min(BIN_COUNT - 1, Math.max(0, Math.floor(v * BIN_COUNT)))]++
+    return bins
+  }, [asOfValues])
+
+  const mean =
+    asOfValues.length > 0 ? asOfValues.reduce((s, v) => s + v, 0) / asOfValues.length : null
+
+  return (
+    <>
+      <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1, mb: 1, flexWrap: 'wrap' }}>
+        <Typography variant="h6">Foilhole distribution</Typography>
+        {mean != null && (
+          <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+            mean {Math.round(mean * 100)}%
+          </Typography>
+        )}
+        <Typography variant="caption" sx={{ color: 'text.disabled' }}>
+          {asOfValues.length}/{sortedSeries.length} foilholes
+        </Typography>
+      </Box>
+
+      <Histogram bins={histogram} />
+
+      {hasRange && (
+        <Box sx={{ px: 1, mt: 0.5 }}>
+          <Slider
+            size="small"
+            min={0}
+            max={1}
+            step={0.01}
+            value={pos}
+            onChange={(_, v) => setPos(typeof v === 'number' ? v : v[0])}
+            aria-label="As of time"
+          />
+          <Typography
+            variant="caption"
+            sx={{ color: 'text.secondary', display: 'block', textAlign: 'center' }}
+          >
+            as of {new Date(selectedTime).toLocaleString()}
+            {pos >= 1 ? ' (latest)' : ''}
+          </Typography>
+        </Box>
+      )}
+    </>
   )
 }
 
@@ -233,7 +325,7 @@ function Histogram({ bins }: { bins: number[] }) {
   const plotH = H - pad.top - pad.bottom
   const barW = plotW / bins.length - 2
   const bars = bins.map((count, i) => ({
-    edge: i / 10,
+    edge: i / bins.length,
     count,
     x: pad.left + (i / bins.length) * plotW + 1,
   }))
@@ -269,7 +361,7 @@ function Histogram({ bins }: { bins: number[] }) {
             y={pad.top + plotH - barH}
             width={barW}
             height={barH}
-            fill={qualityColor(bar.edge + 0.05)}
+            fill={qualityColor(bar.edge + 0.5 / bins.length)}
             opacity="0.7"
             rx="1"
           />


### PR DESCRIPTION
## Summary

Closes the **A3** item from the #132 parity audit — the last A-tier (functional) regression.

The square **Predictions** view's foilhole distribution histogram gains an **"as of time" slider**. Scrubbing it recomputes the histogram from each foilhole's **most recent value at or before the selected time**, so you can watch the distribution build up over the acquisition instead of only seeing the final state. This restores the legacy temporal histogram behaviour (`FoilHolePredictionCharts`).

- Slider defaults to **latest** and is hidden when the metric has no time range.
- Bin count raised **10 → 20** to match the legacy view's resolution.
- Caption reports the as-of timestamp and how many foilholes had a prediction by then (e.g. `1/72 foilholes` early in the run, `72/72` at the end).
- A foilhole with no observation yet at time *T* drops out of the distribution until it first appears (more faithful than legacy's clamp-to-earliest).

## Verification
- `tsc`, Biome, and the production build are clean; lefthook pre-commit/pre-push passed.
- **Real backend (dev k3s):** verified end-to-end on a square with 72 foilholes — the 20-bin histogram renders, and scrubbing the slider from `1:08:19 PM (latest) · 72/72 foilholes` back to `1:07:55 PM · 1/72 foilholes` recomputes the distribution as expected.
- The view degrades gracefully when a metric has no per-foilhole series (empty-state, slider hidden), with no console errors.

Part of #132 (item A3). Independent of #133 (A1/A2) — branched from `main`, no file overlap.
