### PR TITLE
feat(smartem): parity B-items — weights chart, atlas latent picker, workspace config, table columns (#132 B1-B4)

### DIFF
--- a/apps/smartem/src/components/spatial/LatentSpacePanel.tsx
+++ b/apps/smartem/src/components/spatial/LatentSpacePanel.tsx
@@ -1,4 +1,12 @@
-import { Box, Checkbox, FormControlLabel, IconButton, Typography } from '@mui/material'
+import {
+  Box,
+  Checkbox,
+  FormControlLabel,
+  IconButton,
+  MenuItem,
+  Select,
+  Typography,
+} from '@mui/material'
 import { useMemo, useState } from 'react'
 import { PaneFrame } from '~/components/layout/PaneFrame'
 import type { MockLatentCoords } from '~/data/mock-session-detail'
@@ -19,6 +27,11 @@ interface LatentSpacePanelProps {
   onItemHover?: (id: string | null) => void
   // When provided, renders a close button in the pane header (used as the atlas-embedded panel).
   onClose?: () => void
+  // Optional latent-representation model picker (rendered in the footer when more than one model
+  // returned coordinates). The caller owns which model's coordinates feed `items`.
+  models?: { id: string; label: string }[]
+  selectedModel?: string
+  onModelChange?: (id: string) => void
 }
 
 export function LatentSpacePanel({
@@ -27,6 +40,9 @@ export function LatentSpacePanel({
   onItemClick,
   onItemHover,
   onClose,
+  models,
+  selectedModel,
+  onModelChange,
 }: LatentSpacePanelProps) {
   const [showUnselected, setShowUnselected] = useState(true)
 
@@ -56,8 +72,29 @@ export function LatentSpacePanel({
   const toSvgX = (x: number) => pad.left + ((x - minX) / (maxX - minX)) * plotW
   const toSvgY = (y: number) => pad.top + ((maxY - y) / (maxY - minY)) * plotH
 
+  const showModelPicker = !!models && models.length > 1 && !!onModelChange
   const footer = (
     <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, px: 1.5, py: 1 }}>
+      {showModelPicker && (
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+          <Typography variant="caption" sx={{ color: 'text.secondary', fontSize: '0.625rem' }}>
+            Latent
+          </Typography>
+          <Select
+            size="small"
+            variant="standard"
+            value={selectedModel ?? ''}
+            onChange={(e) => onModelChange?.(e.target.value)}
+            sx={{ fontSize: '0.625rem', '& .MuiSelect-select': { py: 0.25, pr: 2.5 } }}
+          >
+            {models?.map((m) => (
+              <MenuItem key={m.id} value={m.id} sx={{ fontSize: '0.75rem' }}>
+                {m.label}
+              </MenuItem>
+            ))}
+          </Select>
+        </Box>
+      )}
       <Box sx={{ flex: 1 }} />
       <FormControlLabel
         control={

--- a/apps/smartem/src/components/weights/WeightsTimeline.tsx
+++ b/apps/smartem/src/components/weights/WeightsTimeline.tsx
@@ -1,11 +1,12 @@
-import { Box, Typography } from '@mui/material'
+import { Box, ButtonBase, Skeleton, Slider, Typography } from '@mui/material'
 import type { QualityPredictionModelWeight } from '@smartem/api'
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import { gray, statusColors } from '~/theme'
 import { CLUSTER_PALETTE } from '~/utils/heatmap'
 
 interface Props {
   weights: QualityPredictionModelWeight[]
+  loading?: boolean
 }
 
 interface MetricSeries {
@@ -24,10 +25,22 @@ function confidence(sdev: number): { label: string; color: string } {
   return { label: 'Confident', color: statusColors.running }
 }
 
+const segSx = (active: boolean) => ({
+  px: 0.75,
+  py: 0.25,
+  borderRadius: 0.5,
+  fontSize: '0.6875rem',
+  fontWeight: active ? 600 : 400,
+  color: active ? 'text.primary' : 'text.secondary',
+  backgroundColor: active ? gray[100] : 'transparent',
+  '&:hover': { backgroundColor: gray[100] },
+})
+
 // Bespoke SVG weight-over-time chart (one line per metric) plus per-metric stats, ported in
 // spirit from the legacy MUI-x-charts component but kept dependency-free to match the app's
-// hand-rolled charts and not pre-empt the open charting-library decision.
-export function WeightsTimeline({ weights }: Props) {
+// hand-rolled charts and not pre-empt the open charting-library decision. Carries the legacy
+// affordances: a time/even x-axis toggle, an x-axis range-crop slider, and a loading skeleton.
+export function WeightsTimeline({ weights, loading }: Props) {
   const series = useMemo<MetricSeries[]>(() => {
     const byMetric = new Map<string, { t: number; weight: number }[]>()
     for (const w of weights) {
@@ -61,6 +74,50 @@ export function WeightsTimeline({ weights }: Props) {
       })
   }, [weights])
 
+  // Distinct, sorted timestamps across all series. Time mode positions points by real time (gaps
+  // preserved); "even" mode positions them by the rank of their timestamp (gaps collapsed), so the
+  // shape is comparable across metrics that were sampled at slightly different instants.
+  const { allTimes, minT, maxT } = useMemo(() => {
+    const set = new Set<number>()
+    for (const s of series) for (const p of s.points) set.add(p.t)
+    const arr = Array.from(set).sort((a, b) => a - b)
+    return { allTimes: arr, minT: arr[0] ?? 0, maxT: arr[arr.length - 1] ?? 0 }
+  }, [series])
+  const rankOf = useMemo(() => {
+    const m = new Map<number, number>()
+    allTimes.forEach((t, i) => {
+      m.set(t, i)
+    })
+    return m
+  }, [allTimes])
+
+  const [timeScale, setTimeScale] = useState(true)
+  const [range, setRange] = useState<number[]>([0, 1])
+
+  if (loading) {
+    return (
+      <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
+        <Box
+          sx={{
+            flex: '1 1 480px',
+            border: '1px solid',
+            borderColor: 'divider',
+            borderRadius: 1,
+            p: 2,
+          }}
+        >
+          <Skeleton variant="text" width={140} sx={{ mb: 1 }} />
+          <Skeleton variant="rounded" height={240} />
+        </Box>
+        <Box sx={{ flex: '1 1 280px', display: 'flex', flexDirection: 'column', gap: 0.75 }}>
+          {[0, 1, 2].map((i) => (
+            <Skeleton key={i} variant="rounded" height={42} />
+          ))}
+        </Box>
+      </Box>
+    )
+  }
+
   if (series.length === 0) {
     return (
       <Typography variant="body2" sx={{ color: 'text.secondary' }}>
@@ -75,11 +132,21 @@ export function WeightsTimeline({ weights }: Props) {
   const plotW = W - pad.left - pad.right
   const plotH = H - pad.top - pad.bottom
 
-  const allT = series.flatMap((s) => s.points.map((p) => p.t))
-  const minT = Math.min(...allT)
-  const maxT = Math.max(...allT)
   const maxW = Math.max(1, ...series.flatMap((s) => s.points.map((p) => p.weight)))
-  const tx = (t: number) => pad.left + (maxT === minT ? 0.5 : (t - minT) / (maxT - minT)) * plotW
+  const lastRank = Math.max(1, allTimes.length - 1)
+
+  // Position of a point along the x-axis as a 0..1 fraction, per the active mode.
+  const fracOf = (t: number) => {
+    if (timeScale) return maxT === minT ? 0.5 : (t - minT) / (maxT - minT)
+    return allTimes.length <= 1 ? 0.5 : (rankOf.get(t) ?? 0) / lastRank
+  }
+  const [lo, hi] = range
+  const span = Math.max(1e-6, hi - lo)
+  const inView = (t: number) => {
+    const f = fracOf(t)
+    return f >= lo - 1e-9 && f <= hi + 1e-9
+  }
+  const tx = (t: number) => pad.left + ((fracOf(t) - lo) / span) * plotW
   const wy = (w: number) => pad.top + (1 - w / maxW) * plotH
 
   return (
@@ -93,9 +160,18 @@ export function WeightsTimeline({ weights }: Props) {
           p: 2,
         }}
       >
-        <Typography variant="h6" sx={{ mb: 1 }}>
-          Weight over time
-        </Typography>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1, flexWrap: 'wrap' }}>
+          <Typography variant="h6">Weight over time</Typography>
+          <Box sx={{ flex: 1 }} />
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.25 }}>
+            <ButtonBase onClick={() => setTimeScale(true)} sx={segSx(timeScale)}>
+              Time
+            </ButtonBase>
+            <ButtonBase onClick={() => setTimeScale(false)} sx={segSx(!timeScale)}>
+              Even
+            </ButtonBase>
+          </Box>
+        </Box>
         <svg
           viewBox={`0 0 ${W} ${H}`}
           style={{ width: '100%', height: 'auto' }}
@@ -136,26 +212,29 @@ export function WeightsTimeline({ weights }: Props) {
             stroke={gray[300]}
             strokeWidth="1"
           />
-          {series.map((s) => (
-            <g key={s.metric}>
-              <polyline
-                points={s.points.map((p) => `${tx(p.t)},${wy(p.weight)}`).join(' ')}
-                fill="none"
-                stroke={s.color}
-                strokeWidth="1.5"
-                opacity="0.9"
-              />
-              {s.points.map((p) => (
-                <circle
-                  key={`${s.metric}-${p.t}`}
-                  cx={tx(p.t)}
-                  cy={wy(p.weight)}
-                  r={2.5}
-                  fill={s.color}
+          {series.map((s) => {
+            const shown = s.points.filter((p) => inView(p.t))
+            return (
+              <g key={s.metric}>
+                <polyline
+                  points={shown.map((p) => `${tx(p.t)},${wy(p.weight)}`).join(' ')}
+                  fill="none"
+                  stroke={s.color}
+                  strokeWidth="1.5"
+                  opacity="0.9"
                 />
-              ))}
-            </g>
-          ))}
+                {shown.map((p) => (
+                  <circle
+                    key={`${s.metric}-${p.t}`}
+                    cx={tx(p.t)}
+                    cy={wy(p.weight)}
+                    r={2.5}
+                    fill={s.color}
+                  />
+                ))}
+              </g>
+            )
+          })}
           <text
             x={pad.left + plotW / 2}
             y={H - 2}
@@ -163,9 +242,21 @@ export function WeightsTimeline({ weights }: Props) {
             fontSize="9"
             fill={gray[500]}
           >
-            time
+            {timeScale ? 'time' : 'point'}
           </text>
         </svg>
+        <Box sx={{ px: 1, mt: 0.5 }}>
+          <Slider
+            size="small"
+            value={range}
+            min={0}
+            max={1}
+            step={0.01}
+            disableSwap
+            onChange={(_, v) => Array.isArray(v) && setRange(v)}
+            aria-label="Time range"
+          />
+        </Box>
       </Box>
 
       <Box sx={{ flex: '1 1 280px', display: 'flex', flexDirection: 'column', gap: 0.75 }}>

--- a/apps/smartem/src/components/workspace/WorkspaceView.tsx
+++ b/apps/smartem/src/components/workspace/WorkspaceView.tsx
@@ -1,5 +1,5 @@
-import { Box, Typography } from '@mui/material'
-import { useMemo } from 'react'
+import { Box, Button, IconButton, Menu, MenuItem, Typography } from '@mui/material'
+import { useCallback, useMemo, useState } from 'react'
 import { AtlasMap } from '~/components/spatial/AtlasMap'
 import type { MockGrid, MockGridSquare } from '~/data/mock-session-detail'
 import { gray, statusColors } from '~/theme'
@@ -9,6 +9,43 @@ interface WorkspaceViewProps {
   grid: MockGrid
   squares: MockGridSquare[]
   onSquareClick: (squareUuid: string) => void
+}
+
+type PanelId = 'atlas' | 'summary' | 'distribution'
+const PANEL_TITLES: Record<PanelId, string> = {
+  atlas: 'Atlas',
+  summary: 'Squares Summary',
+  distribution: 'Quality Distribution',
+}
+const ALL_PANELS: PanelId[] = ['atlas', 'summary', 'distribution']
+
+// Per-user persisted id set (panel hidden/collapsed state), validated against an allow-list so a
+// stale localStorage value can't reference a panel that no longer exists.
+function usePersistedSet(
+  key: string,
+  allowed: string[]
+): [Set<string>, (next: Set<string>) => void] {
+  const [value, setValue] = useState<Set<string>>(() => {
+    try {
+      const raw = typeof window !== 'undefined' ? window.localStorage.getItem(key) : null
+      if (raw) return new Set((JSON.parse(raw) as string[]).filter((id) => allowed.includes(id)))
+    } catch {
+      // ignore parse/storage failures - start empty
+    }
+    return new Set()
+  })
+  const set = useCallback(
+    (next: Set<string>) => {
+      setValue(next)
+      try {
+        window.localStorage.setItem(key, JSON.stringify([...next]))
+      } catch {
+        // ignore storage failures - the in-memory value still applies
+      }
+    },
+    [key]
+  )
+  return [value, set]
 }
 
 export function WorkspaceView({ grid, squares, onSquareClick }: WorkspaceViewProps) {
@@ -31,6 +68,30 @@ export function WorkspaceView({ grid, squares, onSquareClick }: WorkspaceViewPro
     return counts
   }, [squares])
 
+  const [hidden, setHidden] = usePersistedSet('smartem.workspace.hidden', ALL_PANELS)
+  const [collapsed, setCollapsed] = usePersistedSet('smartem.workspace.collapsed', ALL_PANELS)
+  const [addAnchor, setAddAnchor] = useState<null | HTMLElement>(null)
+
+  const toggleCollapse = (id: PanelId) => {
+    const next = new Set(collapsed)
+    next.has(id) ? next.delete(id) : next.add(id)
+    setCollapsed(next)
+  }
+  const removePanel = (id: PanelId) => {
+    const next = new Set(hidden)
+    next.add(id)
+    setHidden(next)
+  }
+  const addPanel = (id: PanelId) => {
+    const next = new Set(hidden)
+    next.delete(id)
+    setHidden(next)
+    setAddAnchor(null)
+  }
+
+  const hiddenList = ALL_PANELS.filter((id) => hidden.has(id))
+  const topVisible = (['atlas', 'summary'] as PanelId[]).filter((id) => !hidden.has(id))
+
   return (
     <Box
       sx={{
@@ -42,158 +103,230 @@ export function WorkspaceView({ grid, squares, onSquareClick }: WorkspaceViewPro
         gap: 2,
       }}
     >
-      {/* Top row: Atlas + Squares summary */}
-      <Box sx={{ display: 'flex', gap: 2, minHeight: 300 }}>
-        {/* Atlas panel */}
-        <Panel title="Atlas" sx={{ flex: 1 }}>
-          <AtlasMap squares={squares} gridName={grid.name} onSquareClick={onSquareClick} />
-        </Panel>
-
-        {/* Squares summary */}
-        <Panel title="Squares Summary" sx={{ flex: 1 }}>
-          <Box sx={{ p: 2 }}>
-            <Box sx={{ display: 'flex', gap: 3, mb: 2 }}>
-              <StatBlock label="Total" value={squares.length} />
-              <StatBlock
-                label="Completed"
-                value={statusCounts.completed}
-                color={statusColors.running}
-              />
-              <StatBlock
-                label="Collected"
-                value={statusCounts.collected}
-                color={statusColors.paused}
-              />
-              <StatBlock
-                label="Registered"
-                value={statusCounts.registered}
-                color={statusColors.offline}
-              />
-            </Box>
-
-            <Typography variant="h6" sx={{ mb: 1 }}>
-              Top squares by quality
-            </Typography>
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
-              {[...squares]
-                .sort((a, b) => b.quality - a.quality)
-                .slice(0, 8)
-                .map((sq) => (
-                  <Box
-                    key={sq.uuid}
-                    onClick={() => onSquareClick(sq.uuid)}
-                    sx={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      gap: 1,
-                      py: 0.5,
-                      px: 1,
-                      borderRadius: 0.5,
-                      cursor: 'pointer',
-                      '&:hover': { backgroundColor: gray[100] },
-                    }}
-                  >
-                    <Box
-                      sx={{
-                        width: 8,
-                        height: 8,
-                        borderRadius: '50%',
-                        backgroundColor: qualityColor(sq.quality),
-                        flexShrink: 0,
-                      }}
-                    />
-                    <Typography variant="caption" sx={{ fontWeight: 500, minWidth: 60 }}>
-                      {sq.gridsquareId}
-                    </Typography>
-                    <Box
-                      sx={{
-                        flex: 1,
-                        height: 4,
-                        backgroundColor: gray[200],
-                        borderRadius: 2,
-                        overflow: 'hidden',
-                      }}
-                    >
-                      <Box
-                        sx={{
-                          width: `${Math.round(sq.quality * 100)}%`,
-                          height: '100%',
-                          backgroundColor: qualityColor(sq.quality),
-                          borderRadius: 2,
-                        }}
-                      />
-                    </Box>
-                    <Typography
-                      variant="caption"
-                      sx={{ fontVariantNumeric: 'tabular-nums', minWidth: 32, textAlign: 'right' }}
-                    >
-                      {Math.round(sq.quality * 100)}%
-                    </Typography>
-                  </Box>
-                ))}
-            </Box>
-          </Box>
-        </Panel>
+      {/* Toolbar: compose which panels are shown. */}
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexShrink: 0 }}>
+        <Typography variant="caption" sx={{ color: 'text.secondary', fontWeight: 600 }}>
+          Workspace
+        </Typography>
+        <Box sx={{ flex: 1 }} />
+        <Button
+          size="small"
+          variant="outlined"
+          disabled={hiddenList.length === 0}
+          onClick={(e) => setAddAnchor(e.currentTarget)}
+          sx={{ fontSize: '0.75rem', py: 0.25 }}
+        >
+          + Add panel
+        </Button>
+        <Menu anchorEl={addAnchor} open={!!addAnchor} onClose={() => setAddAnchor(null)}>
+          {hiddenList.map((id) => (
+            <MenuItem key={id} onClick={() => addPanel(id)} sx={{ fontSize: '0.8125rem' }}>
+              {PANEL_TITLES[id]}
+            </MenuItem>
+          ))}
+        </Menu>
       </Box>
 
-      {/* Full-width: Quality distribution chart */}
-      <Panel title="Quality Distribution">
-        <Box sx={{ p: 2 }}>
-          <svg
-            viewBox="0 0 600 160"
-            style={{ width: '100%', height: 'auto' }}
-            role="img"
-            aria-label="Quality distribution"
-          >
-            {qualityBins.map((count, i) => {
-              const barW = 50
-              const barH = (count / maxBin) * 120
-              const x = 40 + i * 54
-              const y = 130 - barH
-              const midQ = (i + 0.5) / 10
-              const binLabel = (i / 10).toFixed(1)
-              return (
-                <g key={binLabel}>
-                  <rect
-                    x={x}
-                    y={y}
-                    width={barW}
-                    height={barH}
-                    fill={qualityColor(midQ)}
-                    opacity="0.7"
-                    rx="2"
+      {/* Top row: Atlas + Squares summary (each collapsible/removable). */}
+      {topVisible.length > 0 && (
+        <Box sx={{ display: 'flex', gap: 2, alignItems: 'flex-start' }}>
+          {!hidden.has('atlas') && (
+            <Panel
+              title="Atlas"
+              collapsed={collapsed.has('atlas')}
+              onToggleCollapse={() => toggleCollapse('atlas')}
+              onRemove={() => removePanel('atlas')}
+              sx={{ flex: 1, height: collapsed.has('atlas') ? 'auto' : 360 }}
+            >
+              <AtlasMap squares={squares} gridName={grid.name} onSquareClick={onSquareClick} />
+            </Panel>
+          )}
+
+          {!hidden.has('summary') && (
+            <Panel
+              title="Squares Summary"
+              collapsed={collapsed.has('summary')}
+              onToggleCollapse={() => toggleCollapse('summary')}
+              onRemove={() => removePanel('summary')}
+              sx={{ flex: 1, height: collapsed.has('summary') ? 'auto' : 360 }}
+            >
+              <Box sx={{ p: 2 }}>
+                <Box sx={{ display: 'flex', gap: 3, mb: 2 }}>
+                  <StatBlock label="Total" value={squares.length} />
+                  <StatBlock
+                    label="Completed"
+                    value={statusCounts.completed}
+                    color={statusColors.running}
                   />
-                  <text x={x + barW / 2} y={148} textAnchor="middle" fontSize="9" fill={gray[500]}>
-                    {(i / 10).toFixed(1)}
-                  </text>
-                  {count > 0 && (
+                  <StatBlock
+                    label="Collected"
+                    value={statusCounts.collected}
+                    color={statusColors.paused}
+                  />
+                  <StatBlock
+                    label="Registered"
+                    value={statusCounts.registered}
+                    color={statusColors.offline}
+                  />
+                </Box>
+
+                <Typography variant="h6" sx={{ mb: 1 }}>
+                  Top squares by quality
+                </Typography>
+                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+                  {[...squares]
+                    .sort((a, b) => b.quality - a.quality)
+                    .slice(0, 8)
+                    .map((sq) => (
+                      <Box
+                        key={sq.uuid}
+                        onClick={() => onSquareClick(sq.uuid)}
+                        sx={{
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: 1,
+                          py: 0.5,
+                          px: 1,
+                          borderRadius: 0.5,
+                          cursor: 'pointer',
+                          '&:hover': { backgroundColor: gray[100] },
+                        }}
+                      >
+                        <Box
+                          sx={{
+                            width: 8,
+                            height: 8,
+                            borderRadius: '50%',
+                            backgroundColor: qualityColor(sq.quality),
+                            flexShrink: 0,
+                          }}
+                        />
+                        <Typography variant="caption" sx={{ fontWeight: 500, minWidth: 60 }}>
+                          {sq.gridsquareId}
+                        </Typography>
+                        <Box
+                          sx={{
+                            flex: 1,
+                            height: 4,
+                            backgroundColor: gray[200],
+                            borderRadius: 2,
+                            overflow: 'hidden',
+                          }}
+                        >
+                          <Box
+                            sx={{
+                              width: `${Math.round(sq.quality * 100)}%`,
+                              height: '100%',
+                              backgroundColor: qualityColor(sq.quality),
+                              borderRadius: 2,
+                            }}
+                          />
+                        </Box>
+                        <Typography
+                          variant="caption"
+                          sx={{
+                            fontVariantNumeric: 'tabular-nums',
+                            minWidth: 32,
+                            textAlign: 'right',
+                          }}
+                        >
+                          {Math.round(sq.quality * 100)}%
+                        </Typography>
+                      </Box>
+                    ))}
+                </Box>
+              </Box>
+            </Panel>
+          )}
+        </Box>
+      )}
+
+      {/* Full-width: Quality distribution chart. */}
+      {!hidden.has('distribution') && (
+        <Panel
+          title="Quality Distribution"
+          collapsed={collapsed.has('distribution')}
+          onToggleCollapse={() => toggleCollapse('distribution')}
+          onRemove={() => removePanel('distribution')}
+        >
+          <Box sx={{ p: 2 }}>
+            <svg
+              viewBox="0 0 600 160"
+              style={{ width: '100%', height: 'auto' }}
+              role="img"
+              aria-label="Quality distribution"
+            >
+              {qualityBins.map((count, i) => {
+                const barW = 50
+                const barH = (count / maxBin) * 120
+                const x = 40 + i * 54
+                const y = 130 - barH
+                const midQ = (i + 0.5) / 10
+                const binLabel = (i / 10).toFixed(1)
+                return (
+                  <g key={binLabel}>
+                    <rect
+                      x={x}
+                      y={y}
+                      width={barW}
+                      height={barH}
+                      fill={qualityColor(midQ)}
+                      opacity="0.7"
+                      rx="2"
+                    />
                     <text
                       x={x + barW / 2}
-                      y={y - 4}
+                      y={148}
                       textAnchor="middle"
-                      fontSize="8"
-                      fill={gray[600]}
+                      fontSize="9"
+                      fill={gray[500]}
                     >
-                      {count}
+                      {(i / 10).toFixed(1)}
                     </text>
-                  )}
-                </g>
-              )
-            })}
-            <line x1="40" y1="130" x2="580" y2="130" stroke={gray[300]} strokeWidth="1" />
-          </svg>
+                    {count > 0 && (
+                      <text
+                        x={x + barW / 2}
+                        y={y - 4}
+                        textAnchor="middle"
+                        fontSize="8"
+                        fill={gray[600]}
+                      >
+                        {count}
+                      </text>
+                    )}
+                  </g>
+                )
+              })}
+              <line x1="40" y1="130" x2="580" y2="130" stroke={gray[300]} strokeWidth="1" />
+            </svg>
+          </Box>
+        </Panel>
+      )}
+
+      {/* Everything hidden: prompt to re-add. */}
+      {hidden.size === ALL_PANELS.length && (
+        <Box sx={{ p: 4, textAlign: 'center' }}>
+          <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+            All panels hidden — use "Add panel" to bring them back.
+          </Typography>
         </Box>
-      </Panel>
+      )}
     </Box>
   )
 }
 
 function Panel({
   title,
+  collapsed,
+  onToggleCollapse,
+  onRemove,
   children,
   sx,
 }: {
   title: string
+  collapsed?: boolean
+  onToggleCollapse?: () => void
+  onRemove?: () => void
   children: React.ReactNode
   sx?: Record<string, unknown>
 }) {
@@ -214,19 +347,59 @@ function Panel({
           height: 28,
           display: 'flex',
           alignItems: 'center',
-          px: 1.5,
+          gap: 0.5,
+          px: 1,
           backgroundColor: gray[100],
           borderBottom: '1px solid',
           borderColor: 'divider',
           flexShrink: 0,
         }}
       >
+        {onToggleCollapse && (
+          <IconButton
+            size="small"
+            onClick={onToggleCollapse}
+            aria-label={collapsed ? 'Expand panel' : 'Collapse panel'}
+            sx={{ p: 0.25 }}
+          >
+            <Chevron open={!collapsed} />
+          </IconButton>
+        )}
         <Typography variant="caption" sx={{ fontWeight: 600, fontSize: '0.6875rem' }}>
           {title}
         </Typography>
+        <Box sx={{ flex: 1 }} />
+        {onRemove && (
+          <IconButton size="small" onClick={onRemove} aria-label="Remove panel" sx={{ p: 0.25 }}>
+            <svg width="11" height="11" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+              <path
+                d="M3 3l6 6M9 3l-6 6"
+                stroke={gray[600]}
+                strokeWidth="1.5"
+                strokeLinecap="round"
+              />
+            </svg>
+          </IconButton>
+        )}
       </Box>
-      <Box sx={{ flex: 1, overflow: 'auto' }}>{children}</Box>
+      {!collapsed && <Box sx={{ flex: 1, overflow: 'auto', minHeight: 0 }}>{children}</Box>}
     </Box>
+  )
+}
+
+function Chevron({ open }: { open: boolean }) {
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 16 16"
+      fill="currentColor"
+      role="img"
+      aria-hidden="true"
+      style={{ transform: open ? 'rotate(90deg)' : 'none', transition: 'transform 0.12s' }}
+    >
+      <path d="M6 4l4 4-4 4V4z" />
+    </svg>
   )
 }
 

--- a/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.atlas.tsx
+++ b/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.atlas.tsx
@@ -93,27 +93,35 @@ function AtlasView() {
     [suggestedSquares]
   )
 
-  // Latent representation comes from a specific latent-rep model; lacking a picker, use the
-  // first model that returns coordinates and merge them onto the squares.
+  // Latent representation comes from a specific latent-rep model. Collect every model that returned
+  // coordinates (the picker options) and merge the selected model's coordinates onto the squares;
+  // default to the first model with data until the user picks one.
+  const latentByModel = useMemo(() => {
+    const out: { id: string; label: string; coords: Map<string, MockLatentCoords> }[] = []
+    models.forEach((m, i) => {
+      const data = latentResults[i]?.data
+      if (data && data.length > 0) {
+        const coords = latentResponsesToCoordsByUuid(data)
+        if (coords.size > 0) out.push({ id: m.id, label: m.name, coords })
+      }
+    })
+    return out
+  }, [models, latentResults])
+
+  const [latentModel, setLatentModel] = useState('')
+  const activeLatentModel = latentByModel.some((l) => l.id === latentModel)
+    ? latentModel
+    : (latentByModel[0]?.id ?? '')
+
   const squares = useMemo(() => {
     const base = (squareResponses ?? []).map(gridSquareResponseToMock)
-    let latentByUuid: Map<string, MockLatentCoords> | null = null
-    for (const result of latentResults) {
-      if (result?.data && result.data.length > 0) {
-        const map = latentResponsesToCoordsByUuid(result.data)
-        if (map.size > 0) {
-          latentByUuid = map
-          break
-        }
-      }
-    }
-    if (!latentByUuid) return base
-    const lookup = latentByUuid
+    const lookup = latentByModel.find((l) => l.id === activeLatentModel)?.coords
+    if (!lookup) return base
     return base.map((sq) => {
       const latent = lookup.get(sq.uuid)
       return latent ? { ...sq, latent } : sq
     })
-  }, [squareResponses, latentResults])
+  }, [squareResponses, latentByModel, activeLatentModel])
 
   const [showLatent, setShowLatent] = useState(false)
   const [selectedSquareId, setSelectedSquareId] = useState<string | null>(null)
@@ -237,6 +245,9 @@ function AtlasView() {
               if (!frozen) setSelectedSquareId(id)
             }}
             onClose={() => setShowLatent(false)}
+            models={latentByModel.map((l) => ({ id: l.id, label: l.label }))}
+            selectedModel={activeLatentModel}
+            onModelChange={setLatentModel}
           />
         ) : committedSquareId ? (
           <SquarePreviewPanel

--- a/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.squares.index.tsx
+++ b/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.squares.index.tsx
@@ -9,13 +9,16 @@ import {
   TableHead,
   TableRow,
   TableSortLabel,
+  Tooltip,
   Typography,
 } from '@mui/material'
 import type { GridSquareStatus } from '@smartem/api'
 import {
+  getGetGridsquareFoilholesGridsquaresGridsquareUuidFoilholesGetQueryOptions as foilholesQueryOptions,
   useGetGridGridsquaresGridsGridUuidGridsquaresGet,
   useGetGridsquareFoilholesGridsquaresGridsquareUuidFoilholesGet,
 } from '@smartem/api'
+import { useQueries } from '@tanstack/react-query'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { Fragment, useMemo, useState } from 'react'
 import { gray, statusColors } from '~/theme'
@@ -24,7 +27,7 @@ export const Route = createFileRoute('/acquisitions/$acquisitionId/grids/$gridId
   component: SquaresTable,
 })
 
-type SortField = 'defocus' | 'magnification' | 'gridsquareId'
+type SortField = 'defocus' | 'magnification' | 'gridsquareId' | 'holes' | 'score'
 type SortDir = 'asc' | 'desc'
 
 function SquaresTable() {
@@ -35,6 +38,26 @@ function SquaresTable() {
     isLoading,
     error,
   } = useGetGridGridsquaresGridsGridUuidGridsquaresGet(gridId)
+
+  // Per-square foilhole counts and weighted quality, for the Holes/Score columns and their sorts.
+  // Cheap JSON fan-out (one list per square); React Query shares this cache with the expanded
+  // sub-table, so opening a row doesn't refetch.
+  const foilholeQueries = useQueries({
+    queries: (squares ?? []).map((sq) => foilholesQueryOptions(sq.uuid)),
+  })
+  const foilholeStats = useMemo(() => {
+    const m = new Map<string, { count: number; score: number | null }>()
+    ;(squares ?? []).forEach((sq, i) => {
+      const data = foilholeQueries[i]?.data
+      if (!data) return
+      const qualities = data.map((f) => f.quality).filter((q): q is number => q != null)
+      const score = qualities.length
+        ? qualities.reduce((s, v) => s + v, 0) / qualities.length
+        : null
+      m.set(sq.uuid, { count: data.length, score })
+    })
+    return m
+  }, [squares, foilholeQueries])
 
   const [sortField, setSortField] = useState<SortField>('gridsquareId')
   const [sortDir, setSortDir] = useState<SortDir>('asc')
@@ -55,11 +78,15 @@ function SquaresTable() {
       let cmp = 0
       if (sortField === 'defocus') cmp = (a.defocus ?? 0) - (b.defocus ?? 0)
       else if (sortField === 'magnification') cmp = (a.magnification ?? 0) - (b.magnification ?? 0)
+      else if (sortField === 'holes')
+        cmp = (foilholeStats.get(a.uuid)?.count ?? -1) - (foilholeStats.get(b.uuid)?.count ?? -1)
+      else if (sortField === 'score')
+        cmp = (foilholeStats.get(a.uuid)?.score ?? -1) - (foilholeStats.get(b.uuid)?.score ?? -1)
       else cmp = a.gridsquare_id.localeCompare(b.gridsquare_id)
       return sortDir === 'desc' ? -cmp : cmp
     })
     return arr
-  }, [squares, sortField, sortDir])
+  }, [squares, sortField, sortDir, foilholeStats])
 
   const handleSort = (field: SortField) => {
     if (field === sortField) {
@@ -123,11 +150,31 @@ function SquaresTable() {
                 Magnification
               </TableSortLabel>
             </TableCell>
+            <TableCell>
+              <TableSortLabel
+                active={sortField === 'holes'}
+                direction={sortField === 'holes' ? sortDir : 'desc'}
+                onClick={() => handleSort('holes')}
+              >
+                Holes
+              </TableSortLabel>
+            </TableCell>
+            <TableCell>
+              <TableSortLabel
+                active={sortField === 'score'}
+                direction={sortField === 'score' ? sortDir : 'desc'}
+                onClick={() => handleSort('score')}
+              >
+                Score
+              </TableSortLabel>
+            </TableCell>
+            <TableCell sx={{ width: 44 }} />
           </TableRow>
         </TableHead>
         <TableBody>
           {sorted.map((sq) => {
             const isOpen = expanded.has(sq.uuid)
+            const stats = foilholeStats.get(sq.uuid)
             return (
               <Fragment key={sq.uuid}>
                 <TableRow
@@ -188,10 +235,44 @@ function SquaresTable() {
                       {sq.magnification != null ? `${(sq.magnification / 1000).toFixed(0)}k` : '--'}
                     </Typography>
                   </TableCell>
+                  <TableCell>
+                    <Typography
+                      variant="body2"
+                      sx={{ fontVariantNumeric: 'tabular-nums', color: 'text.secondary' }}
+                    >
+                      {stats?.count ?? '--'}
+                    </Typography>
+                  </TableCell>
+                  <TableCell>
+                    <Typography
+                      variant="body2"
+                      sx={{ fontVariantNumeric: 'tabular-nums', color: 'text.secondary' }}
+                    >
+                      {stats?.score != null ? `${Math.round(stats.score * 100)}%` : '--'}
+                    </Typography>
+                  </TableCell>
+                  <TableCell sx={{ width: 44, pr: 1 }}>
+                    <Tooltip title="View predictions">
+                      <IconButton
+                        size="small"
+                        aria-label="View predictions"
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          navigate({
+                            to: '/acquisitions/$acquisitionId/grids/$gridId/squares/$squareId/predictions',
+                            params: { acquisitionId, gridId, squareId: sq.uuid },
+                          })
+                        }}
+                        sx={{ p: 0.25 }}
+                      >
+                        <InsightsGlyph />
+                      </IconButton>
+                    </Tooltip>
+                  </TableCell>
                 </TableRow>
                 {isOpen && (
                   <TableRow>
-                    <TableCell colSpan={6} sx={{ py: 0, backgroundColor: gray[50] }}>
+                    <TableCell colSpan={9} sx={{ py: 0, backgroundColor: gray[50] }}>
                       <FoilholeSubTable squareUuid={sq.uuid} />
                     </TableCell>
                   </TableRow>
@@ -301,6 +382,20 @@ function Chevron({ open }: { open: boolean }) {
       style={{ transform: open ? 'rotate(90deg)' : 'none', transition: 'transform 0.12s' }}
     >
       <path d="M6 4l4 4-4 4V4z" />
+    </svg>
+  )
+}
+
+function InsightsGlyph() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 16 16" fill="none" role="img" aria-hidden="true">
+      <path
+        d="M2 11l3-3 3 2 5-6"
+        stroke={gray[600]}
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
     </svg>
   )
 }

--- a/apps/smartem/src/routes/models.$modelName.tsx
+++ b/apps/smartem/src/routes/models.$modelName.tsx
@@ -23,7 +23,8 @@ function ModelDetail() {
   const [gridChoice, setGridChoice] = useState('')
   const gridUuid = gridChoice || grids?.[0]?.uuid || ''
 
-  const { data: weightsData } = useGetModelWeightsForGridGridGridUuidModelWeightsGet(gridUuid)
+  const { data: weightsData, isLoading: weightsLoading } =
+    useGetModelWeightsForGridGridGridUuidModelWeightsGet(gridUuid)
 
   // The weights endpoint returns every model's weights for the grid; narrow to this model.
   const weightsForModel = useMemo<Record<string, QualityPredictionModelWeight[]>>(
@@ -133,7 +134,7 @@ function ModelDetail() {
 
         {gridUuid ? (
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
-            <WeightsTimeline weights={weightsData?.[modelName] ?? []} />
+            <WeightsTimeline weights={weightsData?.[modelName] ?? []} loading={weightsLoading} />
             <WeightsMatrix weightsByModel={weightsForModel} />
           </Box>
         ) : (


### PR DESCRIPTION
## Summary

Closes the **B-tier** items from the #132 parity audit — the minor reductions left after the A-tier (#133/#134). Four small, independent commits:

- **B1 — weight chart affordances** (`WeightsTimeline`): restored the Time/Even x-axis toggle (real time vs collapsed-gap rank spacing), an x-axis range-crop slider, and a loading skeleton (wired from the weights query's `isLoading`). Stats panel unchanged.
- **B2 — squares table** (`squares.index.tsx`): added a sortable **Holes** (foilhole count) column, a sortable **Score** (weighted mean foilhole quality) column, and a per-row **predictions** button. Per-square foilholes are a light JSON fan-out whose React Query cache is shared with the expandable sub-table (no refetch on expand).
- **B3 — atlas latent-model picker** (`LatentSpacePanel` + atlas route): collect every model that returned coordinates and, when more than one exists, render a model picker in the latent panel footer; the chosen model feeds the scatter. Falls back to the first model with data. Picker props are optional so the square-view latent panel is unaffected.
- **B4 — workspace configurability** (`WorkspaceView`): each panel gains collapse + remove, and a toolbar "Add panel" menu brings hidden panels back. Hidden/collapsed state persists per user in localStorage (matching the gallery).

## Stacking

Branched off `feat/square-latent-panel-and-gallery` (#133), because B2 builds on A2's `squares.tsx` → `squares.index.tsx` restructure and B3 builds on A1's `LatentSpacePanel`. **Merge #133 first**, then this retargets cleanly to `main`. Independent of #134 (A3).

## Verification
- `tsc`, Biome, and the production build are clean; lefthook pre-commit/pre-push passed on every commit.
- **Real backend (dev k3s):** B1 chart renders with real weights (Time/Even toggle + range slider present); B2 Holes column populates with real counts and sort-by-Holes reorders (72 → 191 first); B2 predictions button present per row; B4 add/remove/collapse all work and the "Add panel" menu round-trips. No app console errors.
- **B3** couldn't be exercised end-to-end because this dump has no `latent_representation` data (≤1 latent model → picker correctly hidden by design); the panel and fallback path render without error.

Part of #132 (items B1-B4). Remaining after this: C1 (prod version warning — deliberately dev-only per ADR 0020) and D1 (boring-avatars — cosmetic).
