### PR TITLE
feat(smartem): show suggested acquisition order in the foilhole table

### DIFF
--- a/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.squares.index.tsx
+++ b/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.squares.index.tsx
@@ -17,6 +17,7 @@ import {
   getGetGridsquareFoilholesGridsquaresGridsquareUuidFoilholesGetQueryOptions as foilholesQueryOptions,
   useGetGridGridsquaresGridsGridUuidGridsquaresGet,
   useGetGridsquareFoilholesGridsquaresGridsquareUuidFoilholesGet,
+  useGetOverallPredictionForGridsquareGridsquareGridsquareUuidOverallPredictionGet as useOverallPrediction,
 } from '@smartem/api'
 import { useQueries } from '@tanstack/react-query'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
@@ -29,6 +30,7 @@ export const Route = createFileRoute('/acquisitions/$acquisitionId/grids/$gridId
 
 type SortField = 'defocus' | 'magnification' | 'gridsquareId' | 'holes' | 'score'
 type SortDir = 'asc' | 'desc'
+type FoilholeSortField = 'order' | 'quality'
 
 function SquaresTable() {
   const { acquisitionId, gridId } = Route.useParams()
@@ -286,21 +288,55 @@ function SquaresTable() {
   )
 }
 
-// Lazily loaded when a square row is expanded: its foilholes with a weighted aggregate
-// (mean predicted quality) and a per-foilhole table sortable by quality.
+// Lazily loaded when a square row is expanded: its foilholes joined to the overall-quality
+// prediction, showing the model's suggested acquisition order (issue #98) alongside predicted
+// quality, sortable by either. The order index is grid-wide - holes from other squares interleave -
+// so within a single square the numbers are a monotonic but non-contiguous subset; holes with no
+// prediction yet (index 0) are unranked and always sink to the bottom.
 function FoilholeSubTable({ squareUuid }: { squareUuid: string }) {
   const { data: foilholes, isLoading } =
     useGetGridsquareFoilholesGridsquaresGridsquareUuidFoilholesGet(squareUuid)
-  const [dir, setDir] = useState<SortDir>('desc')
+  const { data: predictions } = useOverallPrediction(squareUuid)
+  const [sortField, setSortField] = useState<FoilholeSortField>('order')
+  const [dir, setDir] = useState<SortDir>('asc')
+
+  // foilhole uuid -> suggested grid-wide acquisition index (1-based; 0 means not yet ordered).
+  const orderByFoilhole = useMemo(() => {
+    const m = new Map<string, number>()
+    for (const p of predictions ?? []) m.set(p.foilhole_uuid, p.suggested_acquisition_index)
+    return m
+  }, [predictions])
 
   const rows = useMemo(() => {
+    const rank = (uuid: string) => {
+      const idx = orderByFoilhole.get(uuid) ?? 0
+      return idx > 0 ? idx : Number.POSITIVE_INFINITY
+    }
     const arr = [...(foilholes ?? [])]
     arr.sort((a, b) => {
+      if (sortField === 'order') {
+        const ra = rank(a.uuid)
+        const rb = rank(b.uuid)
+        if (ra === rb) return 0
+        // Unranked holes stay at the bottom whichever way the column is sorted.
+        if (ra === Number.POSITIVE_INFINITY) return 1
+        if (rb === Number.POSITIVE_INFINITY) return -1
+        return dir === 'desc' ? rb - ra : ra - rb
+      }
       const cmp = (a.quality ?? 0) - (b.quality ?? 0)
       return dir === 'desc' ? -cmp : cmp
     })
     return arr
-  }, [foilholes, dir])
+  }, [foilholes, orderByFoilhole, sortField, dir])
+
+  const handleSort = (field: FoilholeSortField) => {
+    if (field === sortField) {
+      setDir((d) => (d === 'asc' ? 'desc' : 'asc'))
+    } else {
+      setSortField(field)
+      setDir(field === 'order' ? 'asc' : 'desc')
+    }
+  }
 
   if (isLoading) {
     return (
@@ -327,15 +363,26 @@ function FoilholeSubTable({ squareUuid }: { squareUuid: string }) {
         {rows.length} foilholes
         {avg != null ? ` · weighted quality ${Math.round(avg * 100)}%` : ''}
       </Typography>
-      <Table size="small" sx={{ mt: 0.5, maxWidth: 460 }}>
+      <Table size="small" sx={{ mt: 0.5, maxWidth: 520 }}>
         <TableHead>
           <TableRow>
+            <TableCell sx={{ py: 0.25, width: 72 }}>
+              <Tooltip title="Suggested grid-wide acquisition order">
+                <TableSortLabel
+                  active={sortField === 'order'}
+                  direction={sortField === 'order' ? dir : 'asc'}
+                  onClick={() => handleSort('order')}
+                >
+                  Order
+                </TableSortLabel>
+              </Tooltip>
+            </TableCell>
             <TableCell sx={{ py: 0.25 }}>Foilhole</TableCell>
             <TableCell sx={{ py: 0.25 }}>
               <TableSortLabel
-                active
-                direction={dir}
-                onClick={() => setDir((d) => (d === 'asc' ? 'desc' : 'asc'))}
+                active={sortField === 'quality'}
+                direction={sortField === 'quality' ? dir : 'desc'}
+                onClick={() => handleSort('quality')}
               >
                 Quality
               </TableSortLabel>
@@ -344,26 +391,40 @@ function FoilholeSubTable({ squareUuid }: { squareUuid: string }) {
           </TableRow>
         </TableHead>
         <TableBody>
-          {rows.map((fh) => (
-            <TableRow key={fh.uuid}>
-              <TableCell sx={{ py: 0.25 }}>
-                <Typography variant="caption">
-                  {fh.foilhole_id}
-                  {fh.is_near_grid_bar ? ' · grid bar' : ''}
-                </Typography>
-              </TableCell>
-              <TableCell sx={{ py: 0.25 }}>
-                <Typography variant="caption" sx={{ fontVariantNumeric: 'tabular-nums' }}>
-                  {fh.quality != null ? `${Math.round(fh.quality * 100)}%` : '--'}
-                </Typography>
-              </TableCell>
-              <TableCell sx={{ py: 0.25 }}>
-                <Typography variant="caption" sx={{ color: 'text.secondary' }}>
-                  {fh.status}
-                </Typography>
-              </TableCell>
-            </TableRow>
-          ))}
+          {rows.map((fh) => {
+            const order = orderByFoilhole.get(fh.uuid) ?? 0
+            return (
+              <TableRow key={fh.uuid}>
+                <TableCell sx={{ py: 0.25 }}>
+                  <Typography
+                    variant="caption"
+                    sx={{
+                      fontVariantNumeric: 'tabular-nums',
+                      color: order > 0 ? 'text.primary' : 'text.disabled',
+                    }}
+                  >
+                    {order > 0 ? order : '--'}
+                  </Typography>
+                </TableCell>
+                <TableCell sx={{ py: 0.25 }}>
+                  <Typography variant="caption">
+                    {fh.foilhole_id}
+                    {fh.is_near_grid_bar ? ' · grid bar' : ''}
+                  </Typography>
+                </TableCell>
+                <TableCell sx={{ py: 0.25 }}>
+                  <Typography variant="caption" sx={{ fontVariantNumeric: 'tabular-nums' }}>
+                    {fh.quality != null ? `${Math.round(fh.quality * 100)}%` : '--'}
+                  </Typography>
+                </TableCell>
+                <TableCell sx={{ py: 0.25 }}>
+                  <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                    {fh.status}
+                  </Typography>
+                </TableCell>
+              </TableRow>
+            )
+          })}
         </TableBody>
       </Table>
     </Box>

--- a/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.squares.index.tsx
+++ b/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.squares.index.tsx
@@ -307,6 +307,19 @@ function FoilholeSubTable({ squareUuid }: { squareUuid: string }) {
     return m
   }, [predictions])
 
+  // The grid-wide index reads as an arbitrary five-digit number in isolation, so each ranked hole
+  // also gets its position within this square: foilhole uuid -> rank (1-based), out of rankedCount.
+  const { rankInSquare, rankedCount } = useMemo(() => {
+    const ranked = [...orderByFoilhole.entries()]
+      .filter(([, idx]) => idx > 0)
+      .sort((a, b) => a[1] - b[1])
+    const m = new Map<string, number>()
+    ranked.forEach(([uuid], i) => {
+      m.set(uuid, i + 1)
+    })
+    return { rankInSquare: m, rankedCount: ranked.length }
+  }, [orderByFoilhole])
+
   const rows = useMemo(() => {
     const rank = (uuid: string) => {
       const idx = orderByFoilhole.get(uuid) ?? 0
@@ -366,8 +379,8 @@ function FoilholeSubTable({ squareUuid }: { squareUuid: string }) {
       <Table size="small" sx={{ mt: 0.5, maxWidth: 520 }}>
         <TableHead>
           <TableRow>
-            <TableCell sx={{ py: 0.25, width: 72 }}>
-              <Tooltip title="Suggested grid-wide acquisition order">
+            <TableCell sx={{ py: 0.25, width: 116 }}>
+              <Tooltip title="Suggested acquisition order: grid-wide index, with the hole's position within this square">
                 <TableSortLabel
                   active={sortField === 'order'}
                   direction={sortField === 'order' ? dir : 'asc'}
@@ -393,18 +406,34 @@ function FoilholeSubTable({ squareUuid }: { squareUuid: string }) {
         <TableBody>
           {rows.map((fh) => {
             const order = orderByFoilhole.get(fh.uuid) ?? 0
+            const rank = rankInSquare.get(fh.uuid)
             return (
               <TableRow key={fh.uuid}>
                 <TableCell sx={{ py: 0.25 }}>
-                  <Typography
-                    variant="caption"
-                    sx={{
-                      fontVariantNumeric: 'tabular-nums',
-                      color: order > 0 ? 'text.primary' : 'text.disabled',
-                    }}
-                  >
-                    {order > 0 ? order : '--'}
-                  </Typography>
+                  {order > 0 ? (
+                    <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 0.75 }}>
+                      <Typography
+                        variant="caption"
+                        sx={{ fontVariantNumeric: 'tabular-nums', color: 'text.primary' }}
+                      >
+                        {order}
+                      </Typography>
+                      <Typography
+                        variant="caption"
+                        sx={{
+                          fontVariantNumeric: 'tabular-nums',
+                          color: 'text.disabled',
+                          fontSize: '0.6875rem',
+                        }}
+                      >
+                        {rank}/{rankedCount}
+                      </Typography>
+                    </Box>
+                  ) : (
+                    <Typography variant="caption" sx={{ color: 'text.disabled' }}>
+                      --
+                    </Typography>
+                  )}
                 </TableCell>
                 <TableCell sx={{ py: 0.25 }}>
                   <Typography variant="caption">


### PR DESCRIPTION
## What

Surfaces `OverallQualityPrediction.suggested_acquisition_index` as a new **Order** column in the expandable foil-hole sub-table on the grid-squares page. This is the *list* visualisation from #98 (the richer acquisition-path-on-image overlay is a planned follow-up).

The column is the default sort (ascending), so each square's foil holes read top-to-bottom in the order the system suggests collecting them.

## Why

The acquisition order is one of the system's core outputs but was previously invisible in the UI — you could see per-hole quality, but not the sequence the holes would actually be collected in.

## Notes / design calls

- **Grid-wide index.** The index is assigned across the whole grid (`predictions/acquisition.py` → `ordered_holes` writes `i + 1`), so within a single square the numbers are a monotonic but **non-contiguous** subset — holes on other squares interleave. A header tooltip ("Suggested grid-wide acquisition order") makes this explicit rather than faking contiguity.
- **Unranked holes sink to the bottom** in both sort directions. Index `0` means "not yet ordered"; those render as `--`.
- **Lazy fetch.** The per-square overall-prediction query only fires when a row is expanded — no extra upfront fan-out.

## Verification

- `tsc` + Biome clean; lefthook pre-commit passes.
- **Mock mode** (Playwright): column renders in order `Order · Foilhole · Quality · Status`, both sort labels toggle, zero console errors. (Mock cells show `--` because the generated MSW mock's prediction UUIDs don't join to the foil-hole UUIDs.)
- **Live backend** (Playwright, real Keycloak login): probed real data — a square with 125 foil holes had 125 ranked predictions, all 125 joining to the foil-hole list; the Order column rendered real ascending indices; empty squares correctly show "No foilholes recorded"; zero console errors.

Addresses #98.