### PR TITLE
feat(smartem): add an acquisition-path overlay to the square map

### DIFF
--- a/apps/smartem/src/components/spatial/AcquisitionPathOverlay.tsx
+++ b/apps/smartem/src/components/spatial/AcquisitionPathOverlay.tsx
@@ -1,0 +1,157 @@
+// SVG overlay (rendered inside SquareMap's <svg>, in native-pixel viewBox space) that draws the
+// suggested acquisition path through a square's foilholes in order. Three switchable styles let us
+// compare them in the UI before settling on one (issue #98, stage 2):
+//   - 'gradient': a single line graded start->end (blue->orange) with a start dot and end arrow;
+//                 direction reads from colour, no per-node numbers (cleanest on dense squares).
+//   - 'numbered': the line plus a numbered badge at every hole (precise, but dense squares crowd).
+//   - 'sparse':   the line plus an end arrow and numbered badges only at the start, end and a few
+//                 milestones.
+// The group is non-interactive so foilhole hover/click still works through it.
+
+export type PathStyle = 'gradient' | 'numbered' | 'sparse'
+
+export interface PathPoint {
+  uuid: string
+  x: number
+  y: number
+  rank: number
+}
+
+interface AcquisitionPathOverlayProps {
+  points: PathPoint[]
+  total: number
+  style: PathStyle
+  vbW: number
+}
+
+const START_COLOR = '#2f6feb'
+const END_COLOR = '#e59344'
+const LINE_COLOR = '#2f6feb'
+
+function lerpColor(a: string, b: string, t: number): string {
+  const pa = [
+    Number.parseInt(a.slice(1, 3), 16),
+    Number.parseInt(a.slice(3, 5), 16),
+    Number.parseInt(a.slice(5, 7), 16),
+  ]
+  const pb = [
+    Number.parseInt(b.slice(1, 3), 16),
+    Number.parseInt(b.slice(3, 5), 16),
+    Number.parseInt(b.slice(5, 7), 16),
+  ]
+  const c = pa.map((v, i) => Math.round(v + (pb[i] - v) * t))
+  return `rgb(${c[0]}, ${c[1]}, ${c[2]})`
+}
+
+function arrowPoints(from: PathPoint, to: PathPoint, size: number): string {
+  const angle = Math.atan2(to.y - from.y, to.x - from.x)
+  const a1 = angle + Math.PI - Math.PI / 7
+  const a2 = angle + Math.PI + Math.PI / 7
+  const b1x = to.x + size * Math.cos(a1)
+  const b1y = to.y + size * Math.sin(a1)
+  const b2x = to.x + size * Math.cos(a2)
+  const b2y = to.y + size * Math.sin(a2)
+  return `${to.x},${to.y} ${b1x},${b1y} ${b2x},${b2y}`
+}
+
+export function AcquisitionPathOverlay({ points, total, style, vbW }: AcquisitionPathOverlayProps) {
+  if (points.length < 2) return null
+
+  // Sizes scale with the micrograph's native pixel space so they read at any zoom.
+  const stroke = vbW / 480
+  const dotR = vbW / 170
+  const badgeR = vbW / 95
+  const fontSize = vbW / 95
+  const arrowSize = vbW / 70
+
+  const first = points[0]
+  const last = points[points.length - 1]
+  const prevLast = points[points.length - 2]
+  const polyPoints = points.map((p) => `${p.x},${p.y}`).join(' ')
+
+  const badge = (p: PathPoint) => (
+    <g key={`badge-${p.uuid}`}>
+      <circle
+        cx={p.x}
+        cy={p.y}
+        r={badgeR}
+        fill={LINE_COLOR}
+        stroke="#ffffff"
+        strokeWidth={stroke / 2}
+      />
+      <text
+        x={p.x}
+        y={p.y}
+        fill="#ffffff"
+        fontSize={fontSize}
+        fontWeight={600}
+        textAnchor="middle"
+        dominantBaseline="central"
+      >
+        {p.rank}
+      </text>
+    </g>
+  )
+
+  // 'sparse': start, end, and ~4 evenly spaced milestones in between.
+  const step = Math.max(1, Math.round(total / 6))
+  const sparseLabelled = points.filter(
+    (p) => p.rank === 1 || p.rank === total || p.rank % step === 0
+  )
+
+  return (
+    <g style={{ pointerEvents: 'none' }}>
+      {style === 'gradient' ? (
+        points.slice(0, -1).map((p, i) => {
+          const next = points[i + 1]
+          return (
+            <line
+              key={`seg-${p.uuid}`}
+              x1={p.x}
+              y1={p.y}
+              x2={next.x}
+              y2={next.y}
+              stroke={lerpColor(START_COLOR, END_COLOR, i / (points.length - 1))}
+              strokeWidth={stroke}
+              strokeLinecap="round"
+              opacity={0.9}
+            />
+          )
+        })
+      ) : (
+        <polyline
+          points={polyPoints}
+          fill="none"
+          stroke={LINE_COLOR}
+          strokeWidth={stroke}
+          strokeLinejoin="round"
+          strokeLinecap="round"
+          opacity={0.5}
+        />
+      )}
+
+      {/* End-of-path arrowhead for the styles that rely on it for direction. */}
+      {(style === 'gradient' || style === 'sparse') && (
+        <polygon
+          points={arrowPoints(prevLast, last, arrowSize)}
+          fill={style === 'gradient' ? END_COLOR : LINE_COLOR}
+        />
+      )}
+
+      {/* Start marker for the gradient style (the badges already mark it for the others). */}
+      {style === 'gradient' && (
+        <circle
+          cx={first.x}
+          cy={first.y}
+          r={dotR}
+          fill={START_COLOR}
+          stroke="#ffffff"
+          strokeWidth={stroke / 2}
+        />
+      )}
+
+      {style === 'numbered' && points.map(badge)}
+      {style === 'sparse' && sparseLabelled.map(badge)}
+    </g>
+  )
+}

--- a/apps/smartem/src/components/spatial/SquareMap.tsx
+++ b/apps/smartem/src/components/spatial/SquareMap.tsx
@@ -12,6 +12,11 @@ import {
 } from '@mui/material'
 import { useCallback, useMemo, useState } from 'react'
 import { PaneFrame } from '~/components/layout/PaneFrame'
+import {
+  AcquisitionPathOverlay,
+  type PathPoint,
+  type PathStyle,
+} from '~/components/spatial/AcquisitionPathOverlay'
 import type { MockFoilHole } from '~/data/mock-session-detail'
 import { gray, statusColors } from '~/theme'
 import {
@@ -38,6 +43,12 @@ const METRIC_OPTIONS: Record<BaseMetric, HeatmapOptions> = {
 }
 
 const BASE_METRICS = Object.keys(METRIC_OPTIONS) as BaseMetric[]
+
+const PATH_STYLES: { id: PathStyle; label: string }[] = [
+  { id: 'gradient', label: 'Gradient' },
+  { id: 'numbered', label: 'Numbered' },
+  { id: 'sparse', label: 'Sparse' },
+]
 
 const metricButtonSx = (active: boolean) => ({
   px: 0.75,
@@ -77,6 +88,8 @@ interface SquareMapProps {
   predictionValues?: Record<string, Map<string, number>>
   // foilholes the system suggests collecting next; highlighted when the toggle is on
   suggestedHoleIds?: Set<string>
+  // foilhole uuid -> suggested grid-wide acquisition index (1-based); drives the optional path overlay
+  orderByFoilhole?: Map<string, number>
   // "full" (default) fills the viewport with the micrograph and a horizontal control bar - the
   // standalone square page. "panel" is the atlas-embedded preview (issue #68): a compact header, the
   // micrograph fitted to its aspect ratio at the top, and the controls stacked in the space below so
@@ -100,6 +113,7 @@ export function SquareMap({
   predictionLayers = [],
   predictionValues = {},
   suggestedHoleIds,
+  orderByFoilhole,
   variant = 'full',
   onClose,
   onExpand,
@@ -113,6 +127,8 @@ export function SquareMap({
   const [metric, setMetric] = useState<string>('quality')
   const [hideNull, setHideNull] = useState(false)
   const [showSuggestions, setShowSuggestions] = useState(false)
+  const [showPath, setShowPath] = useState(false)
+  const [pathStyle, setPathStyle] = useState<PathStyle>('gradient')
 
   // The micrograph (decoded server-side) lands seconds after the lightweight foilhole geometry.
   // Hold the overlay back until the image has painted so circles and image reveal together; if
@@ -213,6 +229,22 @@ export function SquareMap({
 
   const avgQuality =
     foilholes.length > 0 ? foilholes.reduce((sum, h) => sum + h.quality, 0) / foilholes.length : 0
+
+  // Foilholes that carry a suggested acquisition index, ordered into the path. The index is grid-wide,
+  // so within this square the holes are a sparse slice of it; rank renumbers them 1..M locally.
+  const pathPoints = useMemo<PathPoint[]>(() => {
+    if (!orderByFoilhole || orderByFoilhole.size === 0) return []
+    return foilholes
+      .flatMap((fh) => {
+        const idx = orderByFoilhole.get(fh.uuid)
+        return idx ? [{ fh, idx }] : []
+      })
+      .sort((a, b) => a.idx - b.idx)
+      .map(({ fh }, i) => ({ uuid: fh.uuid, x: fh.xLocation, y: fh.yLocation, rank: i + 1 }))
+  }, [foilholes, orderByFoilhole])
+  const hasPath = pathPoints.length > 1
+  const hoveredRank =
+    showPath && hoveredHole ? pathPoints.find((p) => p.uuid === hoveredHole.uuid)?.rank : undefined
 
   // Foilhole coords live in the micrograph's native pixel space; match the viewBox to it (falling
   // back to the standard gridsquare size until the image decodes) so the overlay stays on the image.
@@ -347,6 +379,41 @@ export function SquareMap({
       </ButtonBase>
     ) : null
 
+  // "Path" enables the acquisition-order overlay; when on, three buttons switch between the styles
+  // so we can compare them on real squares before settling on one (issue #98).
+  const pathControls = hasPath ? (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+      <ButtonBase
+        onClick={() => setShowPath((s) => !s)}
+        sx={{
+          px: 0.75,
+          py: 0.25,
+          borderRadius: 0.5,
+          fontSize: '0.625rem',
+          fontWeight: showPath ? 600 : 400,
+          color: showPath ? '#2f6feb' : 'text.disabled',
+          backgroundColor: showPath ? gray[50] : 'transparent',
+          '&:hover': { backgroundColor: gray[100] },
+        }}
+      >
+        Path
+      </ButtonBase>
+      {showPath && (
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.25 }}>
+          {PATH_STYLES.map((s) => (
+            <ButtonBase
+              key={s.id}
+              onClick={() => setPathStyle(s.id)}
+              sx={metricButtonSx(s.id === pathStyle)}
+            >
+              {s.label}
+            </ButtonBase>
+          ))}
+        </Box>
+      )}
+    </Box>
+  ) : null
+
   const hideNullToggle =
     useHeatmap || isPred ? (
       <FormControlLabel
@@ -471,6 +538,14 @@ export function SquareMap({
               />
             )
           })}
+          {showPath && hasPath && (
+            <AcquisitionPathOverlay
+              points={pathPoints}
+              total={pathPoints.length}
+              style={pathStyle}
+              vbW={vbW}
+            />
+          )}
         </g>
       </svg>
 
@@ -523,6 +598,7 @@ export function SquareMap({
               ? `${hoveredValue ?? 'N/A'} ${METRIC_OPTIONS[baseMetric].label}`
               : `${Math.round(hoveredHole.quality * 100)}%`}
           {hoveredHole.isNearGridBar && ' (near grid bar)'}
+          {hoveredRank != null && ` · order ${hoveredRank}/${pathPoints.length}`}
         </Box>
       )}
     </>
@@ -584,6 +660,7 @@ export function SquareMap({
             {metricSelector}
             <Box sx={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: 1 }}>
               {suggestionsToggle}
+              {pathControls}
               {hideNullToggle}
               <Box sx={{ flex: 1 }} />
               {legend}
@@ -636,6 +713,7 @@ export function SquareMap({
         <Box sx={{ flex: 1 }} />
         {metricSelector}
         {suggestionsToggle}
+        {pathControls}
         {hideNullToggle}
         {legend}
       </Box>

--- a/apps/smartem/src/components/spatial/SquarePreviewPanel.tsx
+++ b/apps/smartem/src/components/spatial/SquarePreviewPanel.tsx
@@ -31,6 +31,7 @@ export function SquarePreviewPanel({
     predictionLayers,
     predictionValues,
     suggestedHoleIds,
+    orderByFoilhole,
   } = useSquareMapData(squareId)
 
   return (
@@ -45,6 +46,7 @@ export function SquarePreviewPanel({
       predictionLayers={predictionLayers}
       predictionValues={predictionValues}
       suggestedHoleIds={suggestedHoleIds}
+      orderByFoilhole={orderByFoilhole}
       onClose={onClose}
       onExpand={() =>
         navigate({

--- a/apps/smartem/src/data/api-adapters.ts
+++ b/apps/smartem/src/data/api-adapters.ts
@@ -227,3 +227,14 @@ export function overallPredictionMap(responses: OverallQualityPrediction[]): Map
   }
   return byFoilhole
 }
+
+// Suggested grid-wide acquisition order per foilhole. Index 0 means "not yet ordered", so it is
+// omitted - callers treat a missing entry as unranked.
+export function overallOrderMap(responses: OverallQualityPrediction[]): Map<string, number> {
+  const byFoilhole = new Map<string, number>()
+  for (const r of responses) {
+    if (r.suggested_acquisition_index > 0)
+      byFoilhole.set(r.foilhole_uuid, r.suggested_acquisition_index)
+  }
+  return byFoilhole
+}

--- a/apps/smartem/src/hooks/useSquareMapData.ts
+++ b/apps/smartem/src/hooks/useSquareMapData.ts
@@ -14,6 +14,7 @@ import {
   foilHoleResponseToMock,
   foilholePredictionMap,
   gridSquareResponseToMock,
+  overallOrderMap,
   overallPredictionMap,
 } from '~/data/api-adapters'
 import type { MockFoilHole } from '~/data/mock-session-detail'
@@ -30,6 +31,8 @@ export interface SquareMapData {
   predictionLayers: PredictionLayer[]
   predictionValues: Record<string, Map<string, number>>
   suggestedHoleIds: Set<string>
+  // foilhole uuid -> suggested grid-wide acquisition index (1-based; unranked holes are absent).
+  orderByFoilhole: Map<string, number>
 }
 
 // Fetches everything SquareMap needs for one gridsquare: foilhole geometry, the authenticated
@@ -106,6 +109,10 @@ export function useSquareMapData(squareId: string): SquareMapData {
     [suggestedHoles]
   )
 
+  // Reuse the overall-prediction response (already fetched for the "Overall" overlay) for the
+  // acquisition-order path; no extra request.
+  const orderByFoilhole = useMemo(() => overallOrderMap(overallResponse ?? []), [overallResponse])
+
   return {
     squareLabel: square?.gridsquareId ?? squareId,
     foilholes,
@@ -116,5 +123,6 @@ export function useSquareMapData(squareId: string): SquareMapData {
     predictionLayers,
     predictionValues,
     suggestedHoleIds,
+    orderByFoilhole,
   }
 }

--- a/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.squares_.$squareId.index.tsx
+++ b/apps/smartem/src/routes/acquisitions.$acquisitionId.grids.$gridId.squares_.$squareId.index.tsx
@@ -31,6 +31,7 @@ function SquareIndexView() {
     predictionLayers,
     predictionValues,
     suggestedHoleIds,
+    orderByFoilhole,
   } = useSquareMapData(squareId)
 
   // Fan out one latent-rep query per model, scoped to this gridsquare. Mirrors the atlas, which does
@@ -86,6 +87,7 @@ function SquareIndexView() {
           predictionLayers={predictionLayers}
           predictionValues={predictionValues}
           suggestedHoleIds={suggestedHoleIds}
+          orderByFoilhole={orderByFoilhole}
           onFoilholeClick={openHole}
           hoveredId={hoveredId}
           onHoveredIdChange={setHoveredId}


### PR DESCRIPTION
## What

Stage 2 of #98 (stage 1 — the Order column — landed in #138). Draws the suggested acquisition order as a **path over the square micrograph**. A **Path** toggle in the `SquareMap` control bar enables it.

It deliberately ships **three styles behind a switcher** so we can compare them on real squares and pick the winner before this is marked ready:

- **Gradient** — a single line graded start→end (blue→orange) with a start dot and end arrow. Direction reads from colour; no per-node numbers. Cleanest on dense squares.
- **Numbered** — the line plus a numbered badge at every hole. Precise, but crowds on dense squares.
- **Sparse** — the line plus an end arrow and badges only at the start, end and ~5 milestones.

Hovering a hole shows its `order N/M` in the tooltip.

## Why this shape

- **No extra request:** reuses the overall-prediction response already fetched for the "Overall" heatmap layer, via a new `overallOrderMap` adapter → `orderByFoilhole` on `useSquareMapData`.
- **Per-square scope:** the index is grid-wide, so a single square's holes are a sparse slice of it; `rank` renumbers them 1..M locally for the path.
- **Non-interactive overlay:** the path `<g>` has `pointer-events: none`, so foilhole hover/click still works through it.
- Threaded through both `SquareMap` consumers (full-page square view and the atlas-embedded panel).

## Verification

- Biome + `tsc` clean; lefthook pre-commit passes.
- Live backend (Playwright, real login): rendered all three styles on a 125-hole square (worst case for legibility) with zero console errors. At that density the gradient is busy and numbered crowds, while sparse stays clean — most squares are far less dense.

## Open decision

Which style to keep. Options: settle on one and strip the others, or keep the switcher as a user-facing control. Leaving it draft until we decide by eye.

Stage 2 of #98 (kept open).