### PR TITLE
refactor: replace vite-tsconfig-paths plugin with a plain resolve alias

### DIFF
--- a/apps/smartem/package.json
+++ b/apps/smartem/package.json
@@ -38,8 +38,7 @@
     "@vitejs/plugin-react": "^6.0.1",
     "rollup-plugin-visualizer": "^7.0.1",
     "tailwindcss": "^4.0.0",
-    "vite": "^8.0.2",
-    "vite-tsconfig-paths": "^6.1.0"
+    "vite": "^8.0.2"
   },
   "msw": {
     "workerDirectory": [

--- a/apps/smartem/vite.config.ts
+++ b/apps/smartem/vite.config.ts
@@ -1,9 +1,9 @@
+import { fileURLToPath } from 'node:url'
 import tailwindcss from '@tailwindcss/vite'
 import { TanStackRouterVite } from '@tanstack/router-vite-plugin'
 import react from '@vitejs/plugin-react'
 import { visualizer } from 'rollup-plugin-visualizer'
 import { defineConfig, loadEnv } from 'vite'
-import tsconfigPaths from 'vite-tsconfig-paths'
 
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '')
@@ -14,7 +14,6 @@ export default defineConfig(({ mode }) => {
       react(),
       tailwindcss(),
       TanStackRouterVite(),
-      tsconfigPaths(),
       mode === 'analyze' &&
         visualizer({
           open: !process.env.CI,
@@ -24,6 +23,7 @@ export default defineConfig(({ mode }) => {
         }),
     ],
     resolve: {
+      alias: { '~': fileURLToPath(new URL('./src', import.meta.url)) },
       dedupe: ['react', 'react-dom', 'react/jsx-runtime', '@mui/material'],
     },
     server: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,8 +82,7 @@
         "@vitejs/plugin-react": "^6.0.1",
         "rollup-plugin-visualizer": "^7.0.1",
         "tailwindcss": "^4.0.0",
-        "vite": "^8.0.2",
-        "vite-tsconfig-paths": "^6.1.0"
+        "vite": "^8.0.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -4196,13 +4195,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/globrex": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
-      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/goober": {
       "version": "2.1.18",
       "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.18.tgz",
@@ -5553,22 +5545,6 @@
         }
       }
     },
-    "node_modules/orval/node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "node_modules/outvariant": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
@@ -6839,58 +6815,6 @@
         "yaml": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vite-tsconfig-paths": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-6.1.1.tgz",
-      "integrity": "sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "globrex": "^0.1.2",
-        "tsconfck": "^3.0.3"
-      },
-      "peerDependencies": {
-        "vite": "*"
-      }
-    },
-    "node_modules/vite-tsconfig-paths/node_modules/tsconfck": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
-      "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "tsconfck": "bin/tsconfck.js"
-      },
-      "engines": {
-        "node": "^18 || >=20"
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vite-tsconfig-paths/node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/vite/node_modules/picomatch": {


### PR DESCRIPTION
## Summary

- Remove the `vite-tsconfig-paths` plugin and its dependency
- Add an explicit `resolve.alias` entry (`~ -> ./src`) that does the same job
- Silences the Vite informational notice about native tsconfig paths support

The `~/...` path mapping in `tsconfig.json` is kept as-is for TypeScript/IDE resolution.

## Test plan

- [ ] `npm run dev` starts without the `vite-tsconfig-paths` warning
- [ ] `~/...` imports resolve correctly in dev and build
- [ ] `npm run typecheck` shows no new errors (pre-existing generated model errors are unrelated)
- [ ] `vite-tsconfig-paths` no longer appears in `package.json` or `package-lock.json`

Closes #139